### PR TITLE
Remove template instructions from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,5 @@
 # ns8-dependencytrack
 
-This is a template module for [NethServer 8](https://github.com/NethServer/ns8-core).
-To start a new module from it:
-
-1. Click on [Use this template](https://github.com/NethServer/ns8-dependencytrack/generate).
-   Name your repo with `ns8-` prefix (e.g. `ns8-mymodule`). 
-   Do not end your module name with a number, like ~~`ns8-baaad2`~~!
-
-1. Clone the repository, enter the cloned directory and
-   [configure your GIT identity](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup#_your_identity)
-
-1. Rename some references inside the repo:
-   ```
-   modulename=$(basename $(pwd) | sed 's/^ns8-//') &&
-   git mv imageroot/systemd/user/dependencytrack.service imageroot/systemd/user/${modulename}.service &&
-   git mv imageroot/systemd/user/dependencytrack-apiserver.service imageroot/systemd/user/${modulename}-app.service && 
-   git mv tests/dependencytrack.robot tests/${modulename}.robot &&
-   sed -i "s/dependencytrack/${modulename}/g" $(find .github/ * -type f) &&
-   git commit -a -m "Repository initialization"
-   ```
-
-1. Edit this `README.md` file, by replacing this section with your module
-   description
-
-1. Adjust `.github/workflows` to your needs. `clean-registry.yml` might
-   need the proper list of image names to work correctly. Unused workflows
-   can be disabled from the GitHub Actions interface.
-
-1. Commit and push your local changes
-
 ## Install
 
 Instantiate the module with:


### PR DESCRIPTION
Eliminate outdated template instructions to streamline the README and improve clarity for users.