### PR TITLE
Remove configuration and functionality tests for Dependency-Track

### DIFF
--- a/tests/dependencytrack.robot
+++ b/tests/dependencytrack.robot
@@ -9,16 +9,6 @@ Check if dependencytrack is installed correctly
     &{output} =    Evaluate    ${output}
     Set Suite Variable    ${module_id}    ${output.module_id}
 
-Check if dependencytrack can be configured
-    ${rc} =    Execute Command    api-cli run module/${module_id}/configure-module --data '{}'
-    ...    return_rc=True  return_stdout=False
-    Should Be Equal As Integers    ${rc}  0
-
-Check if dependencytrack works as expected
-    ${rc} =    Execute Command    curl -f http://127.0.0.1/dependencytrack/
-    ...    return_rc=True  return_stdout=False
-    Should Be Equal As Integers    ${rc}  0
-
 Check if dependencytrack is removed correctly
     ${rc} =    Execute Command    remove-module --no-preserve ${module_id}
     ...    return_rc=True  return_stdout=False


### PR DESCRIPTION
Eliminate tests related to the configuration and expected functionality of Dependency-Track, streamlining the test suite.

https://github.com/NethServer/dev/issues/7477