### PR TITLE
Fix casing in metadata.json for consistency

### DIFF
--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -1,12 +1,12 @@
 {
-  "name": "dependencytrack",
+  "name": "DependencyTrack",
   "description": {
-    "en": "open-source platform for tracking and managing software dependencies"
+    "en": "Open-source platform for tracking and managing software dependencies"
   },
   "categories": [],
   "authors": [
     {
-      "name": "stephane de Labrusse",
+      "name": "Stephane de Labrusse",
       "email": "stephdl@de-labrusse.fr"
     }
   ],


### PR DESCRIPTION
Standardize the casing of fields in metadata.json to improve consistency and readability.

https://github.com/NethServer/dev/issues/7477