### PR TITLE
Remove unused smarthost.env references and update backup file name

### DIFF
--- a/imageroot/actions/configure-module/80start_services
+++ b/imageroot/actions/configure-module/80start_services
@@ -11,7 +11,5 @@ exec 1>&2
 
 # If the control reaches this step, the service can be enabled and started
 
-touch smarthost.env
-
 systemctl --user enable dependencytrack.service
 systemctl --user restart dependencytrack.service

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -5,7 +5,7 @@
 # List here what you want to save during backup : volumes or file Path
 
 
-state/dependencytrack.sql
+state/dependencytrack.pg_dump
 state/secrets.env
 volumes/dtrack-data
 volumes/trivy-cache

--- a/imageroot/systemd/user/dependencytrack-apiserver.service
+++ b/imageroot/systemd/user/dependencytrack-apiserver.service
@@ -11,7 +11,6 @@ After=dependencytrack.service postgresql-app.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
-EnvironmentFile=-%S/state/smarthost.env
 EnvironmentFile=%S/state/secrets.env
 WorkingDirectory=%S/state
 Restart=always

--- a/imageroot/systemd/user/dependencytrack-frontend.service
+++ b/imageroot/systemd/user/dependencytrack-frontend.service
@@ -10,7 +10,6 @@ BindsTo=dependencytrack.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
-EnvironmentFile=-%S/state/smarthost.env
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70

--- a/imageroot/systemd/user/dependencytrack-nginx.service
+++ b/imageroot/systemd/user/dependencytrack-nginx.service
@@ -11,7 +11,6 @@ BindsTo=dependencytrack.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
-EnvironmentFile=-%S/state/smarthost.env
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70


### PR DESCRIPTION
Eliminate unnecessary references to smarthost.env in service files and the service startup script. Update the backup file reference from dependencytrack.sql to dependencytrack.pg_dump.

https://github.com/NethServer/dev/issues/7477