### PR TITLE
Remove postgres-data from backup include patterns

### DIFF
--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -9,4 +9,3 @@ state/dependencytrack.pg_dump
 state/secrets.env
 volumes/dtrack-data
 volumes/trivy-cache
-volumes/postgres-data


### PR DESCRIPTION
Eliminate the inclusion of postgres-data in the backup configuration to streamline the backup process.

NethServer/dev#7477