### PR TITLE
Update Trivy image version in build-images.sh

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -38,7 +38,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@node:routeadm" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/postgres:17.7-alpine3.21 docker.io/dependencytrack/frontend:4.14.1 docker.io/dependencytrack/apiserver:4.14.1 docker.io/aquasec/trivy:0.69.6 docker.io/library/nginx:1.28.2-alpine" \
+    --label="org.nethserver.images=docker.io/postgres:17.7-alpine3.21 docker.io/dependencytrack/frontend:4.14.1 docker.io/dependencytrack/apiserver:4.14.1 docker.io/aquasec/trivy:0.69.3 docker.io/library/nginx:1.28.2-alpine" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"


### PR DESCRIPTION
This pull request makes a minor update to the `build-images.sh` script, specifically adjusting the image version for `trivy` in the `org.nethserver.images` label.

- Updated the `org.nethserver.images` label in `build-images.sh` to use `docker.io/aquasec/trivy:0.69.3` instead of `0.69.6`, ensuring the correct version of the `trivy` image is referenced.Image 0.69.6 does not exist