### PR TITLE
build(ui): always generate module logo image

### DIFF
--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -1,4 +1,15 @@
 module.exports = {
+  chainWebpack: (config) => {
+    config.module
+      .rule("images")
+      .use("url-loader")
+      .loader("url-loader")
+      .tap((options) => {
+        // Do not base64 encode images URLs. Needed to always generate module logo image
+        options.limit = -1;
+        return options;
+      });
+  },
   css: {
     loaderOptions: {
       sass: {


### PR DESCRIPTION
Do not base64 encode images URLs in the webpack build, so the module logo image is always generated as a real file.

Ref:
- https://github.com/NethServer/dev/issues/8136