### PR TITLE
feat: ship the v4 to v5 upgrade script in a v4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,12 @@ On the node hosting the instance, from the copy phase 1 left behind:
 
     runagent -m dependencytrack1 bash upgrade2V5.sh analyzers
 
-This enables and starts the services, replays the v4 analyzer settings against the v5 API,
-then prints what is left to do by hand.
+This refuses to run unless the instance really is on 2.0.0, then enables and starts the
+services, replays the v4 analyzer settings against the v5 API, and prints what is left to do
+by hand.
+
+Portfolio metrics older than 90 days are not carried over. Findings, audit history, policies
+and everything else are.
 
 ### What v5 cannot carry over
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,14 @@ This release ships `imageroot/scripts/upgrade2V5.sh`, which drives the official
 offline. Projects, components, vulnerabilities, findings, policies, users, teams, permissions
 and API keys are preserved.
 
-Take a backup of the instance first. The whole procedure takes the application down.
+Take a backup of the instance first — the whole procedure takes the application down, and it
+rewrites the module database. On the leader node:
+
+    api-cli run list-backups | jq '.backups[]'
+    api-cli run run-backup --data '{"id": <backup id>}'
+
+Run another one as soon as the upgrade is over: every snapshot taken before it holds a v4
+database, and 2.0.0 refuses to restore one.
 
 ### 1. Find the node hosting the instance
 

--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ rewrites the module database. On the leader node:
     api-cli run list-backups | jq '.backups[]'
     api-cli run run-backup --data '{"id": <backup id>}'
 
-The script stops and asks you to type `I have a backup` before it touches anything. Run
+The script stops before it touches anything: it lists what v5 cannot carry over, so you decide
+knowing what you will have to type back in, then asks you to type `I have a backup`. Use
 `--yes` instead only from a script, where there is no terminal to ask on.
 
-Run another backup as soon as the upgrade is over: every snapshot taken before it holds a v4
-database, and 2.0.0 refuses to restore one.
+Going back means restoring a snapshot taken before the upgrade, which brings the instance back
+as it was, on v4.
 
 ### 1. Find the node hosting the instance
 
@@ -138,13 +139,13 @@ is the only way back if the upgrade turns out wrong. It is not included in modul
 it sits on the node's disk and nowhere else — several gigabytes on a real portfolio.
 
 Do not delete it on the same day. First check in the interface that projects, findings, audit
-history, teams and API keys are all there, then run a backup, because every snapshot older
-than the upgrade holds a v4 database this version refuses to restore:
+history, teams and API keys are all there. Then run a backup, so that a snapshot of the
+instance as it is now exists — the ones you already have restore it as it was, on v4:
 
     api-cli run run-backup --data '{"id": <backup id>}'
 
-Once that backup has succeeded, the v4 dump has no reader left. On the node hosting the
-instance:
+Once that backup has succeeded, the v4 dump is no longer the only quick way back. On the node
+hosting the instance:
 
     runagent -m dependencytrack1 du -sh backup-v4
     runagent -m dependencytrack1 rm -rf backup-v4

--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ by hand.
 Portfolio metrics older than 90 days are not carried over. Findings, audit history, policies
 and everything else are.
 
+### 6. Once satisfied, take a backup and reclaim the disk
+
+Phase 1 keeps the v4 database at `state/backup-v4/dependencytrack-v4.pg_dump` on purpose: it
+is the only way back if the upgrade turns out wrong. It is not included in module backups, so
+it sits on the node's disk and nowhere else — several gigabytes on a real portfolio.
+
+Do not delete it on the same day. First check in the interface that projects, findings, audit
+history, teams and API keys are all there, then run a backup, because every snapshot older
+than the upgrade holds a v4 database this version refuses to restore:
+
+    api-cli run run-backup --data '{"id": <backup id>}'
+
+Once that backup has succeeded, the v4 dump has no reader left. On the node hosting the
+instance:
+
+    runagent -m dependencytrack1 du -sh backup-v4
+    runagent -m dependencytrack1 rm -rf backup-v4
+
+The copy of the script under `state/upgrade2V5.sh` and the leftovers in `state/migrate-v5/`
+can go at the same time.
+
 ### What v5 cannot carry over
 
 v5 cannot decrypt what v4 encrypted, so the migrator clears every secret. Repository

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Output example:
 
 ## Configure
 
-Let's assume that the mattermost instance is named `dependencytrack1`.
+Let's assume that the Dependency-Track instance is named `dependencytrack1`.
 
 Launch `configure-module`, by setting the following parameters:
 - `host`: a fully qualified domain name for the application
@@ -33,7 +33,7 @@ EOF
 
 The above command will:
 - start and configure the dependencytrack instance
-- configure a virtual host for trafik to access the instance
+- configure a virtual host for traefik to access the instance
 
 ## Get the configuration
 You can retrieve the configuration with
@@ -53,6 +53,97 @@ To uninstall the instance:
 To Update the instance:
 
     api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/dependencytrack:latest","instances":["dependencytrack1"],"force":true}'
+
+## Upgrading to Dependency-Track v5
+
+Version 2.0.0 of the module runs Dependency-Track v5. v5 is not an in-place upgrade of v4:
+the schemas are incompatible and a v5 API server must never boot against a v4 database, so
+2.0.0 carries `org.nethserver.min-from=2.0.0` and is never offered as an automatic update.
+
+This release ships `imageroot/scripts/upgrade2V5.sh`, which drives the official
+[v4-migrator](https://dependencytrack.github.io/docs/next/guides/administration/migrating-from-v4/)
+offline. Projects, components, vulnerabilities, findings, policies, users, teams, permissions
+and API keys are preserved.
+
+Take a backup of the instance first. The whole procedure takes the application down.
+
+### 1. Find the node hosting the instance
+
+The instance is not necessarily on the leader. On the leader node:
+
+    api-cli run list-installed-modules | jq '.[][] | select(.module == "dependencytrack")'
+
+Note the `node` field, then open a shell on that node, for example
+`ssh root@10.5.4.<node>` over the cluster VPN.
+
+### 2. Update the module to 1.0.12
+
+From the leader, so the instance has the script:
+
+    api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/dependencytrack:1.0.12","instances":["dependencytrack1"],"force":true}'
+
+This release still runs Dependency-Track 4.14.3. Nothing changes but the added script.
+
+### 3. Migrate the database
+
+On the node hosting the instance:
+
+    runagent -m dependencytrack1 bash ../scripts/upgrade2V5.sh
+
+The script stops and disables the pod, dumps the v4 database to
+`state/backup-v4/dependencytrack-v4.pg_dump` and keeps it, saves the v4 analyzer settings
+before the migrator wipes them, copies the data into a fresh v5 database and replaces
+`postgres-data` with it. It also keeps a copy of itself under `state/migrate-v5/`, because
+the next step deletes the original.
+
+Services are left down on purpose, and disabled so a reboot cannot start a v4 API server
+against the migrated database.
+
+### 4. Update the module to 2.0.0
+
+Back on the leader node:
+
+    api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/dependencytrack:2.0.0","instances":["dependencytrack1"],"force":true}'
+
+An explicit `update-module` is not subject to `min-from`, so this works while the Software
+Center still offers nothing.
+
+### 5. Restore the analyzers and start
+
+On the node hosting the instance, from the copy phase 1 left behind:
+
+    runagent -m dependencytrack1 bash migrate-v5/upgrade2V5.sh analyzers
+
+This enables and starts the services, replays the v4 analyzer settings against the v5 API,
+then prints what is left to do by hand.
+
+### What v5 cannot carry over
+
+v5 cannot decrypt what v4 encrypted, so the migrator clears every secret. Repository
+passwords are cleared and their repository disabled, analyzer and integration tokens are
+dropped, and notification rules arrive disabled.
+
+v5 also turned every analyzer and vulnerability source into a plugin whose configuration the
+migrator leaves empty, so the script applies the v4 settings again. An analyzer that was on
+comes back on, one that was off stays off — except for the four that authenticate, because v5
+validates their configuration and refuses to enable them without the API token v4 had
+encrypted.
+
+| Analyzer or source | Carried over |
+| --- | --- |
+| Internal, NVD, OSV, Trivy | fully, including their switches and Trivy's token |
+| OSS Index, GitHub Advisories, Snyk | every setting except the token, so they stay off until you enter it |
+| VulnDB | nothing: v4 authenticated with OAuth1, v5 expects OAuth2 |
+
+OSS Index is the one that bites: v4 queried it anonymously and had it enabled by default,
+while v5 demands a token. A Trivy pointed at some other server is left untouched, since that
+token cannot be recovered either.
+
+### On failure
+
+Services stay stopped, the error is in the journal
+(`journalctl _UID=$(id -u dependencytrack1) -e`), both dumps stay on disk and the run is
+resumable: fix the reported cause and run the script again.
 
 ## Debug
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ On the node hosting the instance:
 The script stops and disables the pod, dumps the v4 database to
 `state/backup-v4/dependencytrack-v4.pg_dump` and keeps it, saves the v4 analyzer settings
 before the migrator wipes them, copies the data into a fresh v5 database and replaces
-`postgres-data` with it. It also keeps a copy of itself under `state/migrate-v5/`, because
-the next step deletes the original.
+`postgres-data` with it. It also keeps a copy of itself as `state/upgrade2V5.sh`, because the
+next step deletes the original.
 
 Services are left down on purpose, and disabled so a reboot cannot start a v4 API server
 against the migrated database.
@@ -119,7 +119,7 @@ Center still offers nothing.
 
 On the node hosting the instance, from the copy phase 1 left behind:
 
-    runagent -m dependencytrack1 bash migrate-v5/upgrade2V5.sh analyzers
+    runagent -m dependencytrack1 bash upgrade2V5.sh analyzers
 
 This enables and starts the services, replays the v4 analyzer settings against the v5 API,
 then prints what is left to do by hand.

--- a/README.md
+++ b/README.md
@@ -56,85 +56,12 @@ To Update the instance:
 
 ## Upgrading to Dependency-Track v5
 
-Module 2.0.0 runs Dependency-Track v5, whose schema is incompatible with v4. It carries
-`org.nethserver.min-from=2.0.0`, so it is never offered as an automatic update.
+This release adds `scripts/upgrade2V5.sh` and changes nothing else: Dependency-Track stays on
+4.14.3. The script has to reach an instance while it is still on v4, which is why it ships
+here and is gone from 2.0.0.
 
-This release ships `scripts/upgrade2V5.sh`, which drives the official
-[v4-migrator](https://dependencytrack.github.io/docs/next/guides/administration/migrating-from-v4/)
-offline. The application is down for the whole procedure.
-
-The script prints what v5 cannot carry over and asks you to type `I have a backup` before it
-touches anything. `--yes` skips the question, for scripts only.
-
-### 1. Find the node
-
-The instance is not necessarily on the leader:
-
-    api-cli run list-installed-modules | jq '.[][] | select(.module == "dependencytrack")'
-
-Open a shell on the node named by `node`, over the cluster VPN: `ssh root@10.5.4.<node>`.
-
-### 2. Update to 1.0.12
-
-From the leader, so the instance has the script. Dependency-Track stays on 4.14.3.
-
-    api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/dependencytrack:1.0.12","instances":["dependencytrack1"],"force":true}'
-
-### 3. Migrate the database
-
-On the node:
-
-    runagent -m dependencytrack1 bash ../scripts/upgrade2V5.sh
-
-It stops and disables the pod, keeps the v4 dump in `state/backup-v4/`, migrates into a fresh
-v5 database and swaps `postgres-data`. Services are left down, and disabled so a reboot cannot
-start a v4 API server against the migrated database.
-
-### 4. Update to 2.0.0
-
-From the leader. An explicit `update-module` is not subject to `min-from`.
-
-    api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/dependencytrack:2.0.0","instances":["dependencytrack1"],"force":true}'
-
-### 5. Restore the analyzers and start
-
-On the node, from the copy phase 1 left behind:
-
-    runagent -m dependencytrack1 bash upgrade2V5.sh analyzers
-
-It refuses to run unless the instance is on 2.0.0, starts the services, replays the v4
-analyzer settings and prints what is left to do by hand.
-
-### 6. Reclaim the disk
-
-The v4 dump is not included in module backups and can be several gigabytes. Once the instance
-checks out, back it up — existing snapshots restore it as it was, on v4 — then:
-
-    api-cli run run-backup --data '{"id": <backup id>}'
-    runagent -m dependencytrack1 rm -rf backup-v4 upgrade2V5.sh migrate-v5
-
-### What v5 cannot carry over
-
-v5 cannot decrypt what v4 encrypted, so every secret is cleared: repository passwords, with
-their repository disabled, analyzer and integration tokens, and notification rules come back
-disabled. Portfolio metrics older than 90 days are dropped. Everything else is preserved.
-
-v5 also turned the analyzers into plugins the migrator leaves unconfigured, so the script
-applies the v4 settings again:
-
-| Analyzer or source | Carried over |
-| --- | --- |
-| Internal, NVD, OSV, Trivy | fully, including Trivy's token |
-| OSS Index, GitHub Advisories, Snyk | everything but the token, so they stay off until you enter it |
-| VulnDB | nothing: v4 used OAuth1, v5 expects OAuth2 |
-
-A Trivy pointed at another server is left alone, its token cannot be recovered either.
-
-### On failure
-
-Services stay down, the error is in the journal
-(`journalctl _UID=$(id -u dependencytrack1) -e`), both dumps stay on disk. Fix the cause and
-run the script again: it resumes.
+Update to this release, then follow the procedure in the
+[2.0.0 README](https://github.com/NethServer/ns8-dependencytrack#upgrading-from-dependency-track-v4-to-v5).
 
 ## Debug
 

--- a/README.md
+++ b/README.md
@@ -56,130 +56,85 @@ To Update the instance:
 
 ## Upgrading to Dependency-Track v5
 
-Version 2.0.0 of the module runs Dependency-Track v5. v5 is not an in-place upgrade of v4:
-the schemas are incompatible and a v5 API server must never boot against a v4 database, so
-2.0.0 carries `org.nethserver.min-from=2.0.0` and is never offered as an automatic update.
+Module 2.0.0 runs Dependency-Track v5, whose schema is incompatible with v4. It carries
+`org.nethserver.min-from=2.0.0`, so it is never offered as an automatic update.
 
-This release ships `imageroot/scripts/upgrade2V5.sh`, which drives the official
+This release ships `scripts/upgrade2V5.sh`, which drives the official
 [v4-migrator](https://dependencytrack.github.io/docs/next/guides/administration/migrating-from-v4/)
-offline. Projects, components, vulnerabilities, findings, policies, users, teams, permissions
-and API keys are preserved.
+offline. The application is down for the whole procedure.
 
-Take a backup of the instance first — the whole procedure takes the application down, and it
-rewrites the module database. On the leader node:
+The script prints what v5 cannot carry over and asks you to type `I have a backup` before it
+touches anything. `--yes` skips the question, for scripts only.
 
-    api-cli run list-backups | jq '.backups[]'
-    api-cli run run-backup --data '{"id": <backup id>}'
+### 1. Find the node
 
-The script stops before it touches anything: it lists what v5 cannot carry over, so you decide
-knowing what you will have to type back in, then asks you to type `I have a backup`. Use
-`--yes` instead only from a script, where there is no terminal to ask on.
-
-Going back means restoring a snapshot taken before the upgrade, which brings the instance back
-as it was, on v4.
-
-### 1. Find the node hosting the instance
-
-The instance is not necessarily on the leader. On the leader node:
+The instance is not necessarily on the leader:
 
     api-cli run list-installed-modules | jq '.[][] | select(.module == "dependencytrack")'
 
-Note the `node` field, then open a shell on that node, for example
-`ssh root@10.5.4.<node>` over the cluster VPN.
+Open a shell on the node named by `node`, over the cluster VPN: `ssh root@10.5.4.<node>`.
 
-### 2. Update the module to 1.0.12
+### 2. Update to 1.0.12
 
-From the leader, so the instance has the script:
+From the leader, so the instance has the script. Dependency-Track stays on 4.14.3.
 
     api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/dependencytrack:1.0.12","instances":["dependencytrack1"],"force":true}'
 
-This release still runs Dependency-Track 4.14.3. Nothing changes but the added script.
-
 ### 3. Migrate the database
 
-On the node hosting the instance:
+On the node:
 
     runagent -m dependencytrack1 bash ../scripts/upgrade2V5.sh
 
-The script stops and disables the pod, dumps the v4 database to
-`state/backup-v4/dependencytrack-v4.pg_dump` and keeps it, saves the v4 analyzer settings
-before the migrator wipes them, copies the data into a fresh v5 database and replaces
-`postgres-data` with it. It also keeps a copy of itself as `state/upgrade2V5.sh`, because the
-next step deletes the original.
+It stops and disables the pod, keeps the v4 dump in `state/backup-v4/`, migrates into a fresh
+v5 database and swaps `postgres-data`. Services are left down, and disabled so a reboot cannot
+start a v4 API server against the migrated database.
 
-Services are left down on purpose, and disabled so a reboot cannot start a v4 API server
-against the migrated database.
+### 4. Update to 2.0.0
 
-### 4. Update the module to 2.0.0
-
-Back on the leader node:
+From the leader. An explicit `update-module` is not subject to `min-from`.
 
     api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/dependencytrack:2.0.0","instances":["dependencytrack1"],"force":true}'
 
-An explicit `update-module` is not subject to `min-from`, so this works while the Software
-Center still offers nothing.
-
 ### 5. Restore the analyzers and start
 
-On the node hosting the instance, from the copy phase 1 left behind:
+On the node, from the copy phase 1 left behind:
 
     runagent -m dependencytrack1 bash upgrade2V5.sh analyzers
 
-This refuses to run unless the instance really is on 2.0.0, then enables and starts the
-services, replays the v4 analyzer settings against the v5 API, and prints what is left to do
-by hand.
+It refuses to run unless the instance is on 2.0.0, starts the services, replays the v4
+analyzer settings and prints what is left to do by hand.
 
-Portfolio metrics older than 90 days are not carried over. Findings, audit history, policies
-and everything else are.
+### 6. Reclaim the disk
 
-### 6. Once satisfied, take a backup and reclaim the disk
-
-Phase 1 keeps the v4 database at `state/backup-v4/dependencytrack-v4.pg_dump` on purpose: it
-is the only way back if the upgrade turns out wrong. It is not included in module backups, so
-it sits on the node's disk and nowhere else — several gigabytes on a real portfolio.
-
-Do not delete it on the same day. First check in the interface that projects, findings, audit
-history, teams and API keys are all there. Then run a backup, so that a snapshot of the
-instance as it is now exists — the ones you already have restore it as it was, on v4:
+The v4 dump is not included in module backups and can be several gigabytes. Once the instance
+checks out, back it up — existing snapshots restore it as it was, on v4 — then:
 
     api-cli run run-backup --data '{"id": <backup id>}'
-
-Once that backup has succeeded, the v4 dump is no longer the only quick way back. On the node
-hosting the instance:
-
-    runagent -m dependencytrack1 du -sh backup-v4
-    runagent -m dependencytrack1 rm -rf backup-v4
-
-The copy of the script under `state/upgrade2V5.sh` and the leftovers in `state/migrate-v5/`
-can go at the same time.
+    runagent -m dependencytrack1 rm -rf backup-v4 upgrade2V5.sh migrate-v5
 
 ### What v5 cannot carry over
 
-v5 cannot decrypt what v4 encrypted, so the migrator clears every secret. Repository
-passwords are cleared and their repository disabled, analyzer and integration tokens are
-dropped, and notification rules arrive disabled.
+v5 cannot decrypt what v4 encrypted, so every secret is cleared: repository passwords, with
+their repository disabled, analyzer and integration tokens, and notification rules come back
+disabled. Portfolio metrics older than 90 days are dropped. Everything else is preserved.
 
-v5 also turned every analyzer and vulnerability source into a plugin whose configuration the
-migrator leaves empty, so the script applies the v4 settings again. An analyzer that was on
-comes back on, one that was off stays off — except for the four that authenticate, because v5
-validates their configuration and refuses to enable them without the API token v4 had
-encrypted.
+v5 also turned the analyzers into plugins the migrator leaves unconfigured, so the script
+applies the v4 settings again:
 
 | Analyzer or source | Carried over |
 | --- | --- |
-| Internal, NVD, OSV, Trivy | fully, including their switches and Trivy's token |
-| OSS Index, GitHub Advisories, Snyk | every setting except the token, so they stay off until you enter it |
-| VulnDB | nothing: v4 authenticated with OAuth1, v5 expects OAuth2 |
+| Internal, NVD, OSV, Trivy | fully, including Trivy's token |
+| OSS Index, GitHub Advisories, Snyk | everything but the token, so they stay off until you enter it |
+| VulnDB | nothing: v4 used OAuth1, v5 expects OAuth2 |
 
-OSS Index is the one that bites: v4 queried it anonymously and had it enabled by default,
-while v5 demands a token. A Trivy pointed at some other server is left untouched, since that
-token cannot be recovered either.
+A Trivy pointed at another server is left alone, its token cannot be recovered either.
 
 ### On failure
 
-Services stay stopped, the error is in the journal
-(`journalctl _UID=$(id -u dependencytrack1) -e`), both dumps stay on disk and the run is
-resumable: fix the reported cause and run the script again.
+Services stay down, the error is in the journal
+(`journalctl _UID=$(id -u dependencytrack1) -e`), both dumps stay on disk. Fix the cause and
+run the script again: it resumes.
 
 ## Debug
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ rewrites the module database. On the leader node:
     api-cli run list-backups | jq '.backups[]'
     api-cli run run-backup --data '{"id": <backup id>}'
 
-Run another one as soon as the upgrade is over: every snapshot taken before it holds a v4
+The script stops and asks you to type `I have a backup` before it touches anything. Run
+`--yes` instead only from a script, where there is no terminal to ask on.
+
+Run another backup as soon as the upgrade is over: every snapshot taken before it holds a v4
 database, and 2.0.0 refuses to restore one.
 
 ### 1. Find the node hosting the instance

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -210,6 +210,41 @@ EOS
     rm -f "${SWAP_FLAG}" "${V5_DUMP}" "${WORK_DIR}/${DB}_restore.sh"
 }
 
+# This is a one way door: the database is rewritten in place, and every snapshot
+# of this instance becomes one this module refuses to restore. Worth a stop.
+#
+# Only asked on a terminal. A non-interactive caller must say so with --yes
+# rather than have the script hang on a read nobody sees.
+confirm_backup() {
+    echo
+    echo "This rewrites the ${MODULE_ID} database in place."
+    echo
+    echo "Every backup snapshot taken before now holds a Dependency-Track v4 database."
+    echo "Once this is done, none of them can be restored into this module any more."
+    echo "Run a backup first if the last one is not recent enough. On the leader node:"
+    echo
+    echo "    api-cli run list-backups | jq '.backups[]'"
+    echo "    api-cli run run-backup --data '{\"id\": <backup id>}'"
+    echo
+
+    if [[ -n "${assume_yes}" ]]; then
+        echo "Proceeding: --yes was given."
+        return 0
+    fi
+
+    if [[ ! -t 0 ]]; then
+        fail "Not running on a terminal, so the confirmation cannot be asked." \
+             "Re-run it from a shell on this node, or pass --yes if you have a backup."
+    fi
+
+    local answer=""
+    read -r -p "Type 'I have a backup' to continue: " answer
+    if [[ "${answer}" != "I have a backup" ]]; then
+        fail "Not confirmed, nothing was changed."
+    fi
+    echo
+}
+
 # Keeps dependencytrack-setup.service of 2.0.0 from configuring Trivy on its own
 # defaults before the analyzer phase replays the v4 ones. Both exits of phase 1
 # need it, the resume path included.
@@ -262,13 +297,7 @@ phase_migrate() {
     }
     trap on_exit EXIT
 
-    echo
-    echo "${SD_WARN}This rewrites the module database. Make sure a backup of ${MODULE_ID} ran"
-    echo "${SD_WARN}recently, and run one now if it did not. On the leader node:"
-    echo "${SD_WARN}    api-cli run list-backups | jq '.backups[]'"
-    echo "${SD_WARN}    api-cli run run-backup --data '{\"id\": <backup id>}'"
-    echo
-
+    confirm_backup
     mkdir -p "${WORK_DIR}"
 
     # Updating to 2.0.0 removes every file the new image does not ship, this one
@@ -658,8 +687,17 @@ fi
 JDBC_SRC="jdbc:postgresql://${SRC_CTR}:5432/${DB}"
 JDBC_DST="jdbc:postgresql://${DST_CTR}:5432/${DB}"
 
-case "${1:-migrate}" in
+assume_yes=""
+phase="migrate"
+for arg in "$@"; do
+    case "${arg}" in
+        --yes) assume_yes=1 ;;
+        migrate | analyzers) phase="${arg}" ;;
+        *) fail "Usage: $0 [migrate|analyzers] [--yes]" ;;
+    esac
+done
+
+case "${phase}" in
     migrate) phase_migrate ;;
     analyzers) phase_analyzers ;;
-    *) fail "Usage: $0 [migrate|analyzers]" ;;
 esac

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -680,7 +680,12 @@ print(json.dumps({"config": config}))')
     echo "${SD_WARN}holds a v4 database, which this version refuses to restore. On the leader node:"
     echo "${SD_WARN}    api-cli run run-backup --data '{\"id\": <backup id>}'"
     echo
-    echo "state/${V4_DUMP} is kept. Remove it once the instance is proven."
+    local dump_size
+    dump_size=$(du -sh "${BACKUP_DIR}" 2>/dev/null | cut -f1)
+    echo "The v4 database is kept at state/${V4_DUMP}${dump_size:+ (${dump_size})}."
+    echo "It is the only way back, and module backups do not include it. Remove it once you"
+    echo "have checked the instance and taken a backup of it:"
+    echo "    runagent -m ${MODULE_ID} rm -rf ${BACKUP_DIR}"
 }
 
 ##

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -243,6 +243,13 @@ phase_migrate() {
     }
     trap on_exit EXIT
 
+    echo
+    echo "${SD_WARN}This rewrites the module database. Make sure a backup of ${MODULE_ID} ran"
+    echo "${SD_WARN}recently, and run one now if it did not. On the leader node:"
+    echo "${SD_WARN}    api-cli run list-backups | jq '.backups[]'"
+    echo "${SD_WARN}    api-cli run run-backup --data '{\"id\": <backup id>}'"
+    echo
+
     mkdir -p "${WORK_DIR}"
 
     # Updating to 2.0.0 removes every file the new image does not ship, this one
@@ -567,6 +574,10 @@ print(json.dumps({"config": config}))')
     echo "${SD_WARN}  - re-enter the repository passwords, their repository is disabled"
     echo "${SD_WARN}  - re-enter the integration keys"
     echo "${SD_WARN}  - re-enable the notification rules, they came back disabled"
+    echo
+    echo "${SD_WARN}Run a backup of ${MODULE_ID} now. Every snapshot taken before this upgrade"
+    echo "${SD_WARN}holds a v4 database, which this version refuses to restore. On the leader node:"
+    echo "${SD_WARN}    api-cli run run-backup --data '{\"id\": <backup id>}'"
     echo
     echo "state/${V4_DUMP} is kept. Remove it once the instance is proven."
 }

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -390,6 +390,9 @@ phase_migrate() {
     run_postgres "${DST_CTR}" "${DST_VOL}" \
         -c max_wal_size=4GB -c max_locks_per_transaction=256
 
+    # `run` is what gates the migration: it exits non-zero on failure and errexit
+    # stops us here. Upstream calls `verify` "advisory post-load checks", so its
+    # exit code proves nothing -- it is kept for what it writes to the journal.
     run_migrator bootstrap
     run_migrator verify
     run_migrator run \

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -392,9 +392,14 @@ phase_migrate() {
 
     # `run` is what gates the migration: it exits non-zero on failure and errexit
     # stops us here. Upstream calls `verify` "advisory post-load checks", so its
-    # exit code proves nothing -- it is kept for what it writes to the journal.
+    # exit code proves nothing -- it is kept for the row count table it writes to
+    # the journal, source against staging against v5.
+    #
+    # Only after `run`. Called before it, verify queries staging tables that
+    # nothing has created yet, so every count raises a PostgreSQL error and the
+    # journal fills with forty "relation does not exist" lines that look like a
+    # failed migration and are not one.
     run_migrator bootstrap
-    run_migrator verify
     run_migrator run \
         --source-url "${JDBC_SRC}" --source-user postgres --source-pass "${POSTGRES_TOKEN}" \
         --metrics-retention-days "${METRICS_RETENTION_DAYS}"

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -221,11 +221,21 @@ EOS
 # rather than have the script hang on a read nobody sees.
 confirm_backup() {
     echo
-    echo "This rewrites the ${MODULE_ID} database in place."
+    echo "This upgrades ${MODULE_ID} to Dependency-Track v5 and rewrites its database"
+    echo "in place. Projects, components, findings, audit history, policies, users,"
+    echo "teams, permissions and API keys are all carried over."
     echo
-    echo "Every backup snapshot taken before now holds a Dependency-Track v4 database."
-    echo "Once this is done, none of them can be restored into this module any more."
-    echo "Run a backup first if the last one is not recent enough. On the leader node:"
+    echo "What v5 cannot carry over, because it cannot decrypt what v4 encrypted:"
+    echo "  - the API tokens of OSS Index, GitHub Advisories, Snyk and VulnDB"
+    echo "    (every other setting of theirs is kept, only the token has to be typed again)"
+    echo "  - repository passwords, and their repository comes back disabled"
+    echo "  - integration keys: Fortify SSC, DefectDojo, Kenna"
+    echo "  - notification rules, which come back disabled"
+    echo "  - the SMTP password, if one was set"
+    echo "Trivy is the exception: this module owns its token and puts it back."
+    echo
+    echo "Going back means restoring a backup snapshot taken before now, which brings"
+    echo "the instance back as it is today, on v4. Take one if the last is not recent:"
     echo
     echo "    api-cli run list-backups | jq '.backups[]'"
     echo "    api-cli run run-backup --data '{\"id\": <backup id>}'"
@@ -672,14 +682,15 @@ print(json.dumps({"config": config}))')
     echo "${SD_WARN}  - re-enter the integration keys"
     echo "${SD_WARN}  - re-enable the notification rules, they came back disabled"
     echo
-    echo "${SD_WARN}Run a backup of ${MODULE_ID} now. Every snapshot taken before this upgrade"
-    echo "${SD_WARN}holds a v4 database, which this version refuses to restore. On the leader node:"
-    echo "${SD_WARN}    api-cli run run-backup --data '{\"id\": <backup id>}'"
+    echo "Worth a backup once you are happy with the result: the snapshots you already"
+    echo "have restore the instance as it was on v4, not as it is now. On the leader node:"
+    echo "    api-cli run run-backup --data '{\"id\": <backup id>}'"
     echo
     local dump_size
     dump_size=$(du -sh "${BACKUP_DIR}" 2>/dev/null | cut -f1)
     echo "The v4 database is kept at state/${V4_DUMP}${dump_size:+ (${dump_size})}."
-    echo "It is the only way back, and module backups do not include it. Remove it once you"
+    echo "It is a faster way back than a restore, and module backups do not include it."
+    echo "Remove it once you"
     echo "have checked the instance and taken a backup of it:"
     echo "    runagent -m ${MODULE_ID} rm -rf ${BACKUP_DIR}"
 }

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -6,26 +6,18 @@
 #
 
 #
-# Upgrade this instance from Dependency-Track v4 to v5.
-#
-# v5 is not an in-place upgrade of v4: the schemas are incompatible and a v5
-# apiserver must never boot against a v4 database. The official v4-migrator
-# copies the data offline into a fresh v5 database:
+# Upgrade this instance from Dependency-Track v4 to v5, with the official
+# v4-migrator:
 #   https://dependencytrack.github.io/docs/next/guides/administration/migrating-from-v4/
 #
-# This script ships with the v4 module and is gone from 2.0.0. Run it as the
-# module user, on the node hosting the instance -- which is not necessarily the
-# leader:
+# Two phases, around an update to 2.0.0 run from the leader:
 #
 #   runagent -m dependencytrack1 bash ../scripts/upgrade2V5.sh
-#
-# It stops there, with the services down, and prints the update-module command
-# to run from the leader. Updating to 2.0.0 deletes this file, so phase 1 keeps
-# a copy of it under state/ for the second phase:
-#
 #   runagent -m dependencytrack1 bash upgrade2V5.sh analyzers
 #
-# On failure both dumps stay on disk and the run is resumable.
+# Phase 1 leaves the services down and keeps a copy of itself under state/,
+# because the update deletes this file. On failure both dumps stay on disk and
+# the run is resumable.
 #
 
 set -E -e -o pipefail
@@ -40,16 +32,13 @@ if [[ -z "${AGENT_STATE_DIR:-}" || -z "${MODULE_ID:-}" ]]; then
     exit 2
 fi
 
-# Resolved before the cd below, because it is usually a relative path.
+# Resolved before the cd: it is usually a relative path.
 SELF=$(readlink -f "$0")
 
-# Callers run from different directories.
 cd "${AGENT_STATE_DIR}"
 
-# The v4 module never runs the migrator, so its image is not in
-# org.nethserver.images and no *_IMAGE variable holds it. The migrator only has
-# to read the v4 schema and write the v5 one: a later apiserver upgrades what it
-# produced through Flyway on its first boot.
+# Not in org.nethserver.images, so no *_IMAGE variable holds it. Its version
+# need not match the apiserver: Flyway upgrades what it produced on first boot.
 V4_MIGRATOR_IMAGE="${V4_MIGRATOR_IMAGE:-ghcr.io/dependencytrack/v4-migrator:5.0.4}"
 
 SRC_CTR="dt_migrate_src"
@@ -63,18 +52,17 @@ UNITS=(dependencytrack.service postgresql-app.service dependencytrack-apiserver.
        dependencytrack-frontend.service dependencytrack-nginx.service trivy-app.service)
 TRIVY_URL="http://127.0.0.1:8282"
 SECRET_NAME="trivy-api-token"
-# Not state/restore/: postgresql-app.service mounts it as
-# /docker-entrypoint-initdb.d/, where a leftover restore script would run.
+# Not state/restore/: postgresql-app.service mounts that as
+# /docker-entrypoint-initdb.d/ and would run whatever is left in it.
 WORK_DIR="migrate-v5"
 V4_DUMP="${BACKUP_DIR}/${DB}-v4.pg_dump"
 V5_DUMP="${WORK_DIR}/${DB}.pg_dump"
 ANALYZERS_ENV="${WORK_DIR}/analyzers.env"
 SELF_COPY="upgrade2V5.sh"
-# Present means a previous run died while replacing postgres-data, so the next
-# run must resume instead of inspecting a volume that is empty at that point.
+# Set while postgres-data is being replaced: the next run must resume rather
+# than inspect a volume that is empty at that point.
 SWAP_FLAG="${WORK_DIR}/.swap-in-progress"
-# Mandatory flag of `run`. Portfolio metrics older than this are not copied over;
-# findings, audit history and everything else are unaffected.
+# Mandatory flag of `run`. Only portfolio metrics older than this are dropped.
 METRICS_RETENTION_DAYS=90
 
 fail() {
@@ -130,10 +118,11 @@ run_migrator() {
         --target-url "${JDBC_DST}" --target-user postgres --target-pass "${POSTGRES_TOKEN}"
 }
 
-# v5 cannot be given an API key, and the analyzer phase needs one. Format and
-# hashing come from Alpine's ApiKeyGenerator.
-# Called in an `if !` condition, which turns errexit off for the whole body, so
-# every step has to report its own failure.
+# v5 accepts no API key from its environment, so it goes in through SQL. Format
+# and hashing come from Alpine's ApiKeyGenerator.
+#
+# Called in an `if !`, which turns errexit off for the whole body: every step
+# reports its own failure.
 create_api_key() {
     local pub sec hash
     read -r pub sec hash < <(python3 - <<'EOS'
@@ -214,11 +203,8 @@ EOS
     rm -f "${SWAP_FLAG}" "${V5_DUMP}" "${WORK_DIR}/${DB}_restore.sh"
 }
 
-# This is a one way door: the database is rewritten in place, and every snapshot
-# of this instance becomes one this module refuses to restore. Worth a stop.
-#
-# Only asked on a terminal. A non-interactive caller must say so with --yes
-# rather than have the script hang on a read nobody sees.
+# Only asked on a terminal: a non-interactive caller says so with --yes rather
+# than hang on a read nobody sees.
 confirm_backup() {
     echo
     echo "This upgrades ${MODULE_ID} to Dependency-Track v5 and rewrites its database"
@@ -259,9 +245,8 @@ confirm_backup() {
     echo
 }
 
-# Keeps dependencytrack-setup.service of 2.0.0 from configuring Trivy on its own
-# defaults before the analyzer phase replays the v4 ones. Both exits of phase 1
-# need it, the resume path included.
+# Keeps dependencytrack-setup.service of 2.0.0 out of the way until phase 2 has
+# replayed the v4 settings. Both exits of phase 1 need it.
 mark_pending() {
     python3 -c 'import agent; agent.set_env("DT_TRIVY_SETUP", "pending-migration")'
 }
@@ -287,7 +272,7 @@ next_step() {
 ## Phase 1: migrate the database, offline, with the module still on v4
 ##
 
-# Not local to phase_migrate: the EXIT trap fires once that function has returned.
+# Not local: the EXIT trap fires once phase_migrate has returned.
 completed=""
 
 phase_migrate() {
@@ -314,22 +299,18 @@ phase_migrate() {
     confirm_backup
     mkdir -p "${WORK_DIR}"
 
-    # Updating to 2.0.0 removes every file the new image does not ship, this one
-    # included, so phase 2 has to run from a copy under state/.
+    # The update removes every file 2.0.0 does not ship, this one included.
     if [[ "${SELF}" != "$(readlink -f "${SELF_COPY}")" ]]; then
         cp -f "${SELF}" "${SELF_COPY}"
     fi
 
-    # Stopped and disabled: a reboot must not start a v4 apiserver on a migrated
-    # database. Every unit has to be disabled, not just the pod: the others are
-    # WantedBy=default.target too, and their BindsTo would drag the pod back up.
+    # Every unit, not just the pod: the others are WantedBy=default.target too,
+    # and their BindsTo would drag the pod back up after a reboot.
     systemctl --user disable "${UNITS[@]}" >/dev/null 2>&1 || true
-    # Every unit by name rather than the pod alone: not relying on BindsTo to
-    # tear the containers down before postgres-data is reopened below.
+    # By name rather than through BindsTo, postgres-data is reopened below.
     systemctl --user stop "${UNITS[@]}"
 
-    # postgres-data is empty or half loaded here: inspecting it would conclude
-    # "fresh install" and replace a database that is already migrated.
+    # postgres-data is empty or half loaded here, so it cannot be inspected.
     if [[ -f "${SWAP_FLAG}" ]]; then
         if [[ ! -f "${V5_DUMP}" ]]; then
             fail "A previous run was interrupted while replacing the database, but" \
@@ -356,7 +337,7 @@ phase_migrate() {
     fi
 
     table_count=$(src_query "SELECT count(*) FROM information_schema.tables WHERE table_schema='public'")
-    # An empty string compares equal to 0 with -eq, and would read as a fresh install.
+    # An empty string equals 0 with -eq, and would read as a fresh install.
     if [[ ! "${table_count}" =~ ^[0-9]+$ ]]; then
         fail "Could not count the tables of the ${DB} database, got '${table_count}'."
     fi
@@ -372,10 +353,8 @@ phase_migrate() {
 
     echo "Dependency-Track v4 schema detected, starting the upgrade to v5."
 
-    # v5 turned the analyzers into plugins whose runtime config the migrator does
-    # not populate, so every switch below has to be carried over by hand. Read
-    # them before the migrator drops them. Defaults are v4's, not v5's: scanOs
-    # and ossindex are on in v4 and off in v5.
+    # The migrator leaves the v5 plugin configs empty, so read the v4 settings
+    # before it drops them. The defaults below are v4's, not v5's.
     read_v4_property() {
         local value
         value=$(src_query "SELECT \"PROPERTYVALUE\" FROM \"CONFIGPROPERTY\"
@@ -383,11 +362,8 @@ phase_migrate() {
         echo "${value:-$3}"
     }
 
-    # An unreadable property must stop the run: recording the v4 default as if
-    # it were the admin's setting would push a wrong value into v5.
-    # Appends on its own rather than under a `{ ... } >file` block: such a block
-    # would capture the message of fail(), and the whole EXIT trap, into the file
-    # and leave the journal empty.
+    # Appends on its own: under a `{ ... } >file` block the message of fail(),
+    # and the whole EXIT trap, would land in the file instead of the journal.
     save_v4_property() {
         local value
         value=$(read_v4_property "$2" "$3" "$4") ||
@@ -428,20 +404,13 @@ phase_migrate() {
     podman exec "${SRC_CTR}" pg_dump -U postgres -Fc "${DB}" >"${V4_DUMP}"
     echo "v4 backup written to state/${V4_DUMP}"
 
-    # Both are raised on the migrator preflight's request: the load writes in bulk
-    # and attaching the metrics partitions takes many locks in one transaction.
+    # Both raised on the migrator preflight's request.
     run_postgres "${DST_CTR}" "${DST_VOL}" \
         -c max_wal_size=4GB -c max_locks_per_transaction=256
 
-    # `run` is what gates the migration: it exits non-zero on failure and errexit
-    # stops us here. Upstream calls `verify` "advisory post-load checks", so its
-    # exit code proves nothing -- it is kept for the row count table it writes to
-    # the journal, source against staging against v5.
-    #
-    # Only after `run`. Called before it, verify queries staging tables that
-    # nothing has created yet, so every count raises a PostgreSQL error and the
-    # journal fills with forty "relation does not exist" lines that look like a
-    # failed migration and are not one.
+    # `run` gates the migration. `verify` is advisory upstream, kept for the row
+    # count table it logs, and only after the load: before it, every count hits a
+    # staging table nothing has created and raises a PostgreSQL error.
     run_migrator bootstrap
     run_migrator run \
         --source-url "${JDBC_SRC}" --source-user postgres --source-pass "${POSTGRES_TOKEN}" \
@@ -457,11 +426,6 @@ phase_migrate() {
     podman exec "${DST_CTR}" pg_dump -U postgres -Fc "${DB}" >"${V5_DUMP}"
     podman rm --ignore -f "${SRC_CTR}" "${DST_CTR}" >/dev/null
 
-    # The v5 images are deliberately not pre-pulled here. The instance is down
-    # from the start of this phase until the end of the analyzer phase, so
-    # fetching them early moves the download inside the same outage rather than
-    # shortening it, while pinning a tag in a released v4 script that can only
-    # drift from what 2.0.0 actually ships. update-module pulls the right ones.
     swap_in_migrated_database
 
     mark_pending
@@ -478,9 +442,8 @@ phase_analyzers() {
         fail "state/${ANALYZERS_ENV} is missing: run the migration phase first."
     fi
 
-    # Shipped by 2.0.0 only. Run out of order this phase would start a v4
-    # apiserver against the migrated v5 database, the one thing phase 1 exists
-    # to prevent.
+    # Shipped by 2.0.0 only. Out of order, this phase would start a v4 apiserver
+    # against the migrated database.
     if [[ ! -f "${AGENT_INSTALL_DIR}/systemd/user/dependencytrack-setup.service" ]]; then
         fail "This instance is not on 2.0.0 yet. Update it first, then run this phase:" \
              "see the command printed at the end of the migration phase."
@@ -495,10 +458,8 @@ phase_analyzers() {
     . "./${ANALYZERS_ENV}"
     set +a
 
-    # v4 stores these with a trailing slash and copes with it; v5 concatenates
-    # and produces a double slash. On OSV that is fatal: the ecosystem archive
-    # at .../osv-vulnerabilities.storage.googleapis.com//Maven/all.zip answers
-    # 404, the mirror retries six times and gives up terminally.
+    # v4 stores these with a trailing slash and copes; v5 concatenates. On OSV
+    # the double slash makes the ecosystem archive answer 404.
     DT_OSV_URL="${DT_OSV_URL%/}"
     DT_NVD_FEEDS_URL="${DT_NVD_FEEDS_URL%/}"
     DT_OSSINDEX_URL="${DT_OSSINDEX_URL%/}"
@@ -508,8 +469,7 @@ phase_analyzers() {
     systemctl --user enable "${UNITS[@]}" dependencytrack-setup.service
     systemctl --user start dependencytrack.service
 
-    # Bringing the instance back up matters more than the analyzers, so this is
-    # checked once the services are running, not before.
+    # After the services are up: bringing the instance back matters more.
     if [[ -z "${api_key}" ]]; then
         python3 -c 'import agent; agent.set_env("DT_TRIVY_SETUP", "")'
         fail "No DT_API_KEY in secrets.env. The instance is up and its data is migrated," \
@@ -517,8 +477,7 @@ phase_analyzers() {
     fi
 
     local api="http://127.0.0.1:${TCP_PORT}/api"
-    # The apiserver runs its init tasks before serving, and the first v5 boot
-    # spends minutes in Flyway.
+    # The first v5 boot spends minutes in Flyway before serving.
     local ready=""
     for _ in $(seq 1 120); do
         if curl -sf -o /dev/null "${api}/version"; then
@@ -540,8 +499,7 @@ phase_analyzers() {
             -d "${body}" || true
     }
 
-    # 304 means what we sent is already stored, which happens whenever a v4
-    # setting matches the v5 default.
+    # 304: what we sent is already stored, a v4 setting matching the v5 default.
     failed=""
     put_extension_config() {
         local point="$1" extension="$2" body="$3" code
@@ -555,17 +513,16 @@ phase_analyzers() {
     }
 
     local trivy_state=none
-    # v4 stores whatever was typed, so compare without a trailing slash: the
-    # module's own Trivy is the one analyzer whose token can be recovered.
+    # Compared without its trailing slash: v4 stores whatever was typed.
     local v4_trivy_url="${DT_TRIVY_URL%/}"
     if [[ -n "${v4_trivy_url}" && "${v4_trivy_url}" != "${TRIVY_URL}" ]]; then
-        # Their token is encrypted and gone, so another server means hands off.
+        # Its token is gone, and only the module's own Trivy can be rebuilt.
         echo "${SD_WARN}Trivy was pointed at ${v4_trivy_url}, not at the server this module runs."
         echo "${SD_WARN}Leaving the analyzer alone: its token cannot be recovered from v4."
     elif [[ -z "${trivy_token}" ]]; then
         echo "${SD_WARN}No Trivy token in secrets.env, leaving the analyzer alone."
     else
-        # 409 means the secret survived from an earlier run, which is just as good.
+        # 409: the secret survived an earlier run.
         local secret_body code
         secret_body=$(N="${SECRET_NAME}" V="${trivy_token}" python3 -c \
             'import json,os;print(json.dumps({"name":os.environ["N"],"value":os.environ["V"]}))')
@@ -589,7 +546,7 @@ print(json.dumps({"config": {
     "ignoreUnfixed": flag("I"),
 }}))')
             if put_extension_config vuln-analyzer trivy "${body}"; then
-                # "prepared": secret and URL in place, but v4 had it off so it stays off.
+                # prepared: URL and token in place, but v4 had it off.
                 if [[ "${DT_TRIVY_ENABLED}" == "true" ]]; then
                     trivy_state=enabled
                 else
@@ -608,8 +565,8 @@ print(json.dumps({"config": {
         'import json,os;print(json.dumps({"config":{"enabled":os.environ["E"].strip().lower()=="true","cveFeedsUrl":os.environ["U"]}}))')
     put_extension_config vuln-data-source nvd "${body}" || true
 
-    # v4 stored the OSV ecosystems as a semicolon separated list, empty meaning off.
-    # v5 keeps them in an array and refuses an empty one while enabled.
+    # v4: semicolon separated, empty meaning off. v5: an array it refuses empty
+    # while enabled.
     body=$(L="${DT_OSV_ECOSYSTEMS}" U="${DT_OSV_URL}" A="${DT_OSV_ALIAS_SYNC}" python3 -c '
 import json, os
 ecosystems = [e.strip() for e in os.environ["L"].split(";") if e.strip()]

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -23,7 +23,7 @@
 # to run from the leader. Updating to 2.0.0 deletes this file, so phase 1 keeps
 # a copy of it under state/ for the second phase:
 #
-#   runagent -m dependencytrack1 bash migrate-v5/upgrade2V5.sh analyzers
+#   runagent -m dependencytrack1 bash upgrade2V5.sh analyzers
 #
 # On failure both dumps stay on disk and the run is resumable.
 #
@@ -63,6 +63,8 @@ NET="dt_migrate_net"
 DST_VOL="postgres-migrate-v5"
 DB="dependencytrack"
 BACKUP_DIR="backup-v4"
+UNITS=(dependencytrack.service postgresql-app.service dependencytrack-apiserver.service
+       dependencytrack-frontend.service dependencytrack-nginx.service trivy-app.service)
 TRIVY_URL="http://127.0.0.1:8282"
 SECRET_NAME="trivy-api-token"
 # Not state/restore/: postgresql-app.service mounts it as
@@ -71,7 +73,7 @@ WORK_DIR="migrate-v5"
 V4_DUMP="${BACKUP_DIR}/${DB}-v4.pg_dump"
 V5_DUMP="${WORK_DIR}/${DB}.pg_dump"
 ANALYZERS_ENV="${WORK_DIR}/analyzers.env"
-SELF_COPY="${WORK_DIR}/upgrade2V5.sh"
+SELF_COPY="upgrade2V5.sh"
 # Present means a previous run died while replacing postgres-data, so the next
 # run must resume instead of inspecting a volume that is empty at that point.
 SWAP_FLAG="${WORK_DIR}/.swap-in-progress"
@@ -133,6 +135,8 @@ run_migrator() {
 
 # v5 cannot be given an API key, and the analyzer phase needs one. Format and
 # hashing come from Alpine's ApiKeyGenerator.
+# Called in an `if !` condition, which turns errexit off for the whole body, so
+# every step has to report its own failure.
 create_api_key() {
     local pub sec hash
     read -r pub sec hash < <(python3 - <<'EOS'
@@ -142,9 +146,10 @@ pub = "".join(secrets.choice(alphabet) for _ in range(8))
 sec = "".join(secrets.choice(alphabet) for _ in range(32))
 print(pub, sec, hashlib.sha3_256(sec.encode()).hexdigest())
 EOS
-    )
+    ) || return 1
+    [[ -n "${pub}" && -n "${sec}" && -n "${hash}" ]] || return 1
 
-    podman exec -i "${DST_CTR}" psql -U postgres -d "${DB}" -v ON_ERROR_STOP=1 -q <<EOS
+    podman exec -i "${DST_CTR}" psql -U postgres -d "${DB}" -v ON_ERROR_STOP=1 -q <<EOS || return 1
 DO \$\$
 DECLARE team_id bigint; key_id bigint;
 BEGIN
@@ -161,7 +166,7 @@ END
 \$\$;
 EOS
 
-    DT_API_KEY="odt_${pub}_${sec}" python3 - <<'EOS'
+    DT_API_KEY="odt_${pub}_${sec}" python3 - <<'EOS' || return 1
 import os, agent
 env = agent.read_envfile("secrets.env")
 env["DT_API_KEY"] = os.environ["DT_API_KEY"]
@@ -258,9 +263,10 @@ phase_migrate() {
         cp -f "${SELF}" "${SELF_COPY}"
     fi
 
-    # Stopped and disabled: a reboot must not start a v4 apiserver on a
-    # migrated database.
-    systemctl --user disable dependencytrack.service >/dev/null 2>&1 || true
+    # Stopped and disabled: a reboot must not start a v4 apiserver on a migrated
+    # database. Every unit has to be disabled, not just the pod: the others are
+    # WantedBy=default.target too, and their BindsTo would drag the pod back up.
+    systemctl --user disable "${UNITS[@]}" >/dev/null 2>&1 || true
     if systemctl --user --quiet is-active dependencytrack.service; then
         systemctl --user stop dependencytrack.service
     fi
@@ -315,12 +321,17 @@ phase_migrate() {
     read_v4_property() {
         local value
         value=$(src_query "SELECT \"PROPERTYVALUE\" FROM \"CONFIGPROPERTY\"
-                            WHERE \"GROUPNAME\" = '$1' AND \"PROPERTYNAME\" = '$2'")
+                            WHERE \"GROUPNAME\" = '$1' AND \"PROPERTYNAME\" = '$2'") || return 1
         echo "${value:-$3}"
     }
 
+    # An unreadable property must stop the run: recording the v4 default as if
+    # it were the admin's setting would push a wrong value into v5.
     save_v4_property() {
-        printf '%s=%q\n' "$1" "$(read_v4_property "$2" "$3" "$4")"
+        local value
+        value=$(read_v4_property "$2" "$3" "$4") ||
+            fail "Could not read the v4 setting $2/$3 from the database."
+        printf '%s=%q\n' "$1" "${value}"
     }
 
     {
@@ -411,19 +422,26 @@ phase_analyzers() {
     . "./${ANALYZERS_ENV}"
     set +a
 
-    systemctl --user enable dependencytrack.service
+    systemctl --user enable "${UNITS[@]}"
     # Shipped by 2.0.0 only, and it stands down while DT_TRIVY_SETUP is set.
     systemctl --user enable dependencytrack-setup.service 2>/dev/null || true
     systemctl --user start dependencytrack.service
 
     local api="http://127.0.0.1:${TCP_PORT}/api"
-    # The apiserver runs its init tasks before serving, which takes a while.
+    # The apiserver runs its init tasks before serving, and the first v5 boot
+    # spends minutes in Flyway.
+    local ready=""
     for _ in $(seq 1 120); do
         if curl -sf -o /dev/null "${api}/version"; then
+            ready=1
             break
         fi
         sleep 5
     done
+    if [[ -z "${ready}" ]]; then
+        fail "The apiserver did not answer within 10 minutes. Check its journal, then run" \
+             "this phase again: it is safe to repeat."
+    fi
 
     call() {
         local method="$1" path="$2" body="$3"

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -1,0 +1,590 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+#
+# Upgrade this instance from Dependency-Track v4 to v5.
+#
+# v5 is not an in-place upgrade of v4: the schemas are incompatible and a v5
+# apiserver must never boot against a v4 database. The official v4-migrator
+# copies the data offline into a fresh v5 database:
+#   https://dependencytrack.github.io/docs/next/guides/administration/migrating-from-v4/
+#
+# This script ships with the v4 module and is gone from 2.0.0. Run it as the
+# module user, on the node hosting the instance -- which is not necessarily the
+# leader:
+#
+#   runagent -m dependencytrack1 bash ../scripts/upgrade2V5.sh
+#
+# It stops there, with the services down, and prints the update-module command
+# to run from the leader. Updating to 2.0.0 deletes this file, so phase 1 keeps
+# a copy of it under state/ for the second phase:
+#
+#   runagent -m dependencytrack1 bash migrate-v5/upgrade2V5.sh analyzers
+#
+# On failure both dumps stay on disk and the run is resumable.
+#
+
+set -E -e -o pipefail
+exec 1>&2 # Redirect any output to the journal (stderr)
+
+SD_ERR='<3>'
+SD_WARN='<4>'
+
+if [[ -z "${AGENT_STATE_DIR:-}" || -z "${MODULE_ID:-}" ]]; then
+    echo "${SD_ERR}This script must run in the module context:" \
+         "runagent -m <instance> bash ../scripts/upgrade2V5.sh"
+    exit 2
+fi
+
+# Resolved before the cd below, because it is usually a relative path.
+SELF=$(readlink -f "$0")
+
+# Callers run from different directories.
+cd "${AGENT_STATE_DIR}"
+
+# The v4 module never runs the migrator, so its image is not in
+# org.nethserver.images and no *_IMAGE variable holds it. The migrator only has
+# to read the v4 schema and write the v5 one: a later apiserver upgrades what it
+# produced through Flyway on its first boot.
+V4_MIGRATOR_IMAGE="${V4_MIGRATOR_IMAGE:-ghcr.io/dependencytrack/v4-migrator:5.0.4}"
+# Pre-pulled to shorten the outage. A mismatch with what 2.0.0 ships costs a
+# wasted download and nothing else, so this is never fatal.
+V5_APISERVER_IMAGE="${V5_APISERVER_IMAGE:-docker.io/dependencytrack/apiserver:5.0.4}"
+V5_FRONTEND_IMAGE="${V5_FRONTEND_IMAGE:-docker.io/dependencytrack/frontend:5.0.4}"
+
+SRC_CTR="dt_migrate_src"
+DST_CTR="dt_migrate_dst"
+LOAD_CTR="dt_migrate_load"
+NET="dt_migrate_net"
+DST_VOL="postgres-migrate-v5"
+DB="dependencytrack"
+BACKUP_DIR="backup-v4"
+TRIVY_URL="http://127.0.0.1:8282"
+SECRET_NAME="trivy-api-token"
+# Not state/restore/: postgresql-app.service mounts it as
+# /docker-entrypoint-initdb.d/, where a leftover restore script would run.
+WORK_DIR="migrate-v5"
+V4_DUMP="${BACKUP_DIR}/${DB}-v4.pg_dump"
+V5_DUMP="${WORK_DIR}/${DB}.pg_dump"
+ANALYZERS_ENV="${WORK_DIR}/analyzers.env"
+SELF_COPY="${WORK_DIR}/upgrade2V5.sh"
+# Present means a previous run died while replacing postgres-data, so the next
+# run must resume instead of inspecting a volume that is empty at that point.
+SWAP_FLAG="${WORK_DIR}/.swap-in-progress"
+# Mandatory flag of `run`.
+METRICS_RETENTION_DAYS=90
+
+fail() {
+    echo "${SD_ERR}$*"
+    exit 1
+}
+
+read_secret() {
+    grep -E "^$1=" secrets.env | cut -d= -f2- || true
+}
+
+# `podman volume rm` and `podman network rm` have no --ignore flag, so probe first.
+cleanup_temp() {
+    podman rm --ignore -f "${SRC_CTR}" "${DST_CTR}" "${LOAD_CTR}" >/dev/null 2>&1 || true
+    if podman network exists "${NET}"; then
+        podman network rm "${NET}" >/dev/null || true
+    fi
+    if podman volume exists "${DST_VOL}"; then
+        podman volume rm --force "${DST_VOL}" >/dev/null || true
+    fi
+}
+
+wait_ready() {
+    local ctr="$1" tries=0
+    until podman exec "${ctr}" pg_isready -U postgres -d "${DB}" >/dev/null 2>&1; do
+        tries=$((tries + 1))
+        if [[ ${tries} -ge 60 ]]; then
+            fail "Timed out waiting for ${ctr} to accept connections"
+        fi
+        sleep 2
+    done
+}
+
+run_postgres() {
+    local name="$1" volume="$2"
+    shift 2
+    podman run -d --replace --name "${name}" --network "${NET}" \
+        --volume "${volume}:/var/lib/postgresql/data:Z" \
+        --env POSTGRES_USER=postgres \
+        --env POSTGRES_PASSWORD="${POSTGRES_TOKEN}" \
+        --env POSTGRES_DB="${DB}" \
+        --env TZ=UTC \
+        "${POSTGRES_IMAGE}" "$@" >/dev/null
+    wait_ready "${name}"
+}
+
+src_query() {
+    podman exec "${SRC_CTR}" psql -U postgres -d "${DB}" -tAc "$1"
+}
+
+run_migrator() {
+    podman run --rm --network "${NET}" --env TZ=UTC "${V4_MIGRATOR_IMAGE}" "$@" \
+        --target-url "${JDBC_DST}" --target-user postgres --target-pass "${POSTGRES_TOKEN}"
+}
+
+# v5 cannot be given an API key, and the analyzer phase needs one. Format and
+# hashing come from Alpine's ApiKeyGenerator.
+create_api_key() {
+    local pub sec hash
+    read -r pub sec hash < <(python3 - <<'EOS'
+import hashlib, secrets
+alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456879"
+pub = "".join(secrets.choice(alphabet) for _ in range(8))
+sec = "".join(secrets.choice(alphabet) for _ in range(32))
+print(pub, sec, hashlib.sha3_256(sec.encode()).hexdigest())
+EOS
+    )
+
+    podman exec -i "${DST_CTR}" psql -U postgres -d "${DB}" -v ON_ERROR_STOP=1 -q <<EOS
+DO \$\$
+DECLARE team_id bigint; key_id bigint;
+BEGIN
+    INSERT INTO "TEAM" ("NAME", "UUID")
+        VALUES ('NethServer module', gen_random_uuid()::text) RETURNING "ID" INTO team_id;
+    INSERT INTO "TEAMS_PERMISSIONS" ("TEAM_ID", "PERMISSION_ID")
+        SELECT team_id, "ID" FROM "PERMISSION"
+         WHERE "NAME" IN ('SECRET_MANAGEMENT', 'SYSTEM_CONFIGURATION');
+    INSERT INTO "APIKEY" ("COMMENT", "CREATED", "SECRET_HASH", "PUBLIC_ID", "IS_LEGACY")
+        VALUES ('Used by the NethServer module', now(), '${hash}', '${pub}', false)
+        RETURNING "ID" INTO key_id;
+    INSERT INTO "APIKEYS_TEAMS" ("TEAM_ID", "APIKEY_ID") VALUES (team_id, key_id);
+END
+\$\$;
+EOS
+
+    DT_API_KEY="odt_${pub}_${sec}" python3 - <<'EOS'
+import os, agent
+env = agent.read_envfile("secrets.env")
+env["DT_API_KEY"] = os.environ["DT_API_KEY"]
+agent.write_envfile("secrets.env", env)
+EOS
+}
+
+# Same reload idiom as actions/restore-module/40restore_database.
+swap_in_migrated_database() {
+    cat - >"${WORK_DIR}/${DB}_restore.sh" <<'EOS'
+# Read dump file from standard input:
+pg_restore --no-owner --no-privileges -U postgres -d dependencytrack
+ec=$?
+docker_temp_server_stop
+exit $ec
+EOS
+
+    touch "${SWAP_FLAG}"
+    if podman volume exists postgres-data; then
+        podman volume rm --force postgres-data >/dev/null
+    fi
+    podman volume create postgres-data >/dev/null
+
+    podman run --rm --interactive --network=none \
+        --volume "./${WORK_DIR}:/docker-entrypoint-initdb.d/:Z" \
+        --volume "postgres-data:/var/lib/postgresql/data:Z" \
+        --replace --name "${LOAD_CTR}" \
+        --env POSTGRES_USER=postgres \
+        --env POSTGRES_PASSWORD="${POSTGRES_TOKEN}" \
+        --env POSTGRES_DB="${DB}" \
+        --env TZ=UTC \
+        "${POSTGRES_IMAGE}" <"${V5_DUMP}"
+
+    rm -f "${SWAP_FLAG}" "${V5_DUMP}" "${WORK_DIR}/${DB}_restore.sh"
+}
+
+next_step() {
+    echo
+    echo "The database is migrated and the services are stopped and disabled."
+    echo "Now update the instance to 2.0.0. On the leader node, run:"
+    echo
+    echo "  api-cli run update-module --data '{\"module_url\":" \
+         "\"ghcr.io/nethserver/dependencytrack:2.0.0\", \"instances\":" \
+         "[\"${MODULE_ID}\"], \"force\":true}'"
+    echo
+    echo "then come back to this node and run:"
+    echo
+    echo "  runagent -m ${MODULE_ID} bash ${SELF_COPY} analyzers"
+    echo
+    echo "That update deletes this script, which is why phase 1 kept a copy at"
+    echo "state/${SELF_COPY}."
+}
+
+##
+## Phase 1: migrate the database, offline, with the module still on v4
+##
+
+# Not local to phase_migrate: the EXIT trap fires once that function has returned.
+completed=""
+
+phase_migrate() {
+    # An ERR trap would miss the `exit 1` of the checks below.
+    on_exit() {
+        local rc=$?
+        cleanup_temp
+        if [[ -n "${completed}" ]]; then
+            return
+        fi
+        echo "${SD_ERR}Upgrade to Dependency-Track v5 failed (exit ${rc}). Services are left"
+        echo "${SD_ERR}stopped on purpose: a v5 apiserver must not run against a v4 database."
+        if [[ -f "${SWAP_FLAG}" && -f "${V5_DUMP}" ]]; then
+            echo "${SD_ERR}The database was being replaced. The migrated dump is kept at"
+            echo "${SD_ERR}state/${V5_DUMP} and the next run resumes from it."
+        fi
+        if [[ -f "${V4_DUMP}" ]]; then
+            echo "${SD_ERR}The v4 data is dumped at state/${V4_DUMP}"
+        fi
+        echo "${SD_ERR}Fix the reported error, then run this script again to retry."
+    }
+    trap on_exit EXIT
+
+    mkdir -p "${WORK_DIR}"
+
+    # Updating to 2.0.0 removes every file the new image does not ship, this one
+    # included, so phase 2 has to run from a copy under state/.
+    if [[ "${SELF}" != "$(readlink -f "${SELF_COPY}")" ]]; then
+        cp -f "${SELF}" "${SELF_COPY}"
+    fi
+
+    # Stopped and disabled: a reboot must not start a v4 apiserver on a
+    # migrated database.
+    systemctl --user disable dependencytrack.service >/dev/null 2>&1 || true
+    if systemctl --user --quiet is-active dependencytrack.service; then
+        systemctl --user stop dependencytrack.service
+    fi
+
+    # postgres-data is empty or half loaded here: inspecting it would conclude
+    # "fresh install" and replace a database that is already migrated.
+    if [[ -f "${SWAP_FLAG}" ]]; then
+        if [[ ! -f "${V5_DUMP}" ]]; then
+            fail "A previous run was interrupted while replacing the database, but" \
+                 "state/${V5_DUMP} is gone. Restore state/${V4_DUMP} into a v4 instance by hand."
+        fi
+        echo "Resuming an interrupted migration from state/${V5_DUMP}."
+        swap_in_migrated_database
+        completed=1
+        next_step
+        return 0
+    fi
+
+    podman pull "${V4_MIGRATOR_IMAGE}"
+
+    cleanup_temp
+    podman network create "${NET}" >/dev/null
+    run_postgres "${SRC_CTR}" postgres-data
+
+    # v5 tracks its schema with Flyway, v4 with DataNucleus and Liquibase.
+    if [[ "$(src_query "SELECT to_regclass('public.flyway_schema_history') IS NOT NULL")" == "t" ]]; then
+        fail "This database is already on the v5 schema. If the module is still on v4," \
+             "update it to 2.0.0 and run this script again with the analyzers argument."
+    fi
+
+    table_count=$(src_query "SELECT count(*) FROM information_schema.tables WHERE table_schema='public'")
+    # An empty string compares equal to 0 with -eq, and would read as a fresh install.
+    if [[ ! "${table_count}" =~ ^[0-9]+$ ]]; then
+        fail "Could not count the tables of the ${DB} database, got '${table_count}'."
+    fi
+
+    if [[ "${table_count}" -eq 0 ]]; then
+        fail "This database is empty. Install 2.0.0 directly instead of upgrading."
+    fi
+
+    if [[ "$(src_query "SELECT to_regclass('public.\"SCHEMAVERSION\"') IS NOT NULL OR to_regclass('public.\"EVENTSERVICELOG\"') IS NOT NULL")" != "t" ]]; then
+        fail "The database holds tables but neither a v4 nor a v5 schema marker." \
+             "Refusing to guess: migrate it by hand first."
+    fi
+
+    echo "Dependency-Track v4 schema detected, starting the upgrade to v5."
+
+    # v5 turned the analyzers into plugins whose runtime config the migrator does
+    # not populate, so every switch below has to be carried over by hand. Read
+    # them before the migrator drops them. Defaults are v4's, not v5's: scanOs
+    # and ossindex are on in v4 and off in v5.
+    read_v4_property() {
+        local value
+        value=$(src_query "SELECT \"PROPERTYVALUE\" FROM \"CONFIGPROPERTY\"
+                            WHERE \"GROUPNAME\" = '$1' AND \"PROPERTYNAME\" = '$2'")
+        echo "${value:-$3}"
+    }
+
+    save_v4_property() {
+        printf '%s=%q\n' "$1" "$(read_v4_property "$2" "$3" "$4")"
+    }
+
+    {
+        save_v4_property DT_TRIVY_URL scanner trivy.base.url ""
+        save_v4_property DT_TRIVY_ENABLED scanner trivy.enabled false
+        save_v4_property DT_TRIVY_IGNORE_UNFIXED scanner trivy.ignore.unfixed false
+        save_v4_property DT_TRIVY_SCAN_LIBRARY scanner trivy.scanner.scanLibrary true
+        save_v4_property DT_TRIVY_SCAN_OS scanner trivy.scanner.scanOs true
+        save_v4_property DT_INTERNAL_ENABLED scanner internal.enabled true
+        save_v4_property DT_NVD_ENABLED vuln-source nvd.enabled true
+        save_v4_property DT_NVD_FEEDS_URL vuln-source nvd.feeds.url https://nvd.nist.gov/feeds
+        save_v4_property DT_OSV_ECOSYSTEMS vuln-source google.osv.enabled ""
+        save_v4_property DT_OSV_URL vuln-source google.osv.base.url https://osv-vulnerabilities.storage.googleapis.com
+        save_v4_property DT_OSV_ALIAS_SYNC vuln-source google.osv.alias.sync.enabled false
+        save_v4_property DT_OSSINDEX_ENABLED scanner ossindex.enabled true
+        save_v4_property DT_OSSINDEX_URL scanner ossindex.base.url https://ossindex.sonatype.org
+        save_v4_property DT_OSSINDEX_USERNAME scanner ossindex.api.username ""
+        save_v4_property DT_OSSINDEX_ALIAS_SYNC scanner ossindex.alias.sync.enabled true
+        save_v4_property DT_GITHUB_ENABLED vuln-source github.advisories.enabled false
+        save_v4_property DT_GITHUB_URL vuln-source github.advisories.api.url https://api.github.com/graphql
+        save_v4_property DT_GITHUB_ALIAS_SYNC vuln-source github.advisories.alias.sync.enabled true
+        save_v4_property DT_SNYK_ENABLED scanner snyk.enabled false
+        save_v4_property DT_SNYK_URL scanner snyk.base.url https://api.snyk.io
+        save_v4_property DT_SNYK_ORG_ID scanner snyk.org.id ""
+        save_v4_property DT_SNYK_ALIAS_SYNC scanner snyk.alias.sync.enabled false
+        save_v4_property DT_VULNDB_ENABLED scanner vulndb.enabled false
+    } >"${ANALYZERS_ENV}"
+    echo "v4 analyzer settings saved to state/${ANALYZERS_ENV}"
+
+    mkdir -p "${BACKUP_DIR}"
+    podman exec "${SRC_CTR}" pg_dump -U postgres -Fc "${DB}" >"${V4_DUMP}"
+    echo "v4 backup written to state/${V4_DUMP}"
+
+    # Both are raised on the migrator preflight's request: the load writes in bulk
+    # and attaching the metrics partitions takes many locks in one transaction.
+    run_postgres "${DST_CTR}" "${DST_VOL}" \
+        -c max_wal_size=4GB -c max_locks_per_transaction=256
+
+    run_migrator bootstrap
+    run_migrator verify
+    run_migrator run \
+        --source-url "${JDBC_SRC}" --source-user postgres --source-pass "${POSTGRES_TOKEN}" \
+        --metrics-retention-days "${METRICS_RETENTION_DAYS}"
+    run_migrator verify
+    run_migrator cleanup
+
+    if ! create_api_key; then
+        echo "${SD_WARN}Could not create an API key for the module: the analyzers will have to"
+        echo "${SD_WARN}be configured by hand."
+    fi
+
+    podman exec "${DST_CTR}" pg_dump -U postgres -Fc "${DB}" >"${V5_DUMP}"
+    podman rm --ignore -f "${SRC_CTR}" "${DST_CTR}" >/dev/null
+
+    # Downloaded while the migrated dump is safe on disk but before the swap, so
+    # a slow registry does not stretch the window with a half-replaced volume.
+    podman pull "${V5_APISERVER_IMAGE}" "${V5_FRONTEND_IMAGE}" || \
+        echo "${SD_WARN}Could not pre-pull the v5 images, update-module will fetch them."
+
+    swap_in_migrated_database
+
+    # Keeps dependencytrack-setup.service of 2.0.0 from configuring Trivy on its
+    # own defaults before the analyzer phase replays the v4 ones.
+    python3 -c 'import agent; agent.set_env("DT_TRIVY_SETUP", "pending-migration")'
+
+    completed=1
+    next_step
+}
+
+##
+## Phase 2: carry the v4 analyzers over, with the module on 2.0.0
+##
+
+phase_analyzers() {
+    if [[ ! -f "${ANALYZERS_ENV}" ]]; then
+        fail "state/${ANALYZERS_ENV} is missing: run the migration phase first."
+    fi
+
+    local api_key trivy_token
+    api_key=$(read_secret DT_API_KEY)
+    trivy_token=$(read_secret TRIVY_TOKEN)
+    if [[ -z "${api_key}" ]]; then
+        fail "No DT_API_KEY in secrets.env: configure the analyzers by hand."
+    fi
+
+    set -a
+    # shellcheck disable=SC1090
+    . "./${ANALYZERS_ENV}"
+    set +a
+
+    systemctl --user enable dependencytrack.service
+    # Shipped by 2.0.0 only, and it stands down while DT_TRIVY_SETUP is set.
+    systemctl --user enable dependencytrack-setup.service 2>/dev/null || true
+    systemctl --user start dependencytrack.service
+
+    local api="http://127.0.0.1:${TCP_PORT}/api"
+    # The apiserver runs its init tasks before serving, which takes a while.
+    for _ in $(seq 1 120); do
+        if curl -sf -o /dev/null "${api}/version"; then
+            break
+        fi
+        sleep 5
+    done
+
+    call() {
+        local method="$1" path="$2" body="$3"
+        curl -sS -o /dev/null -w '%{http_code}' -X "${method}" "${api}/v2${path}" \
+            -H "X-Api-Key: ${api_key}" \
+            -H "Content-Type: application/json" \
+            -d "${body}" || true
+    }
+
+    # 304 means what we sent is already stored, which happens whenever a v4
+    # setting matches the v5 default.
+    put_extension_config() {
+        local point="$1" extension="$2" body="$3" code
+        code=$(call PUT "/extension-points/${point}/extensions/${extension}/config" "${body}")
+        case "${code}" in
+            200 | 204 | 304) return 0 ;;
+        esac
+        echo "${SD_WARN}Could not configure ${extension} (HTTP ${code}), do it by hand."
+        return 1
+    }
+
+    local trivy_state=none
+    if [[ -n "${DT_TRIVY_URL}" && "${DT_TRIVY_URL}" != "${TRIVY_URL}" ]]; then
+        # Their token is encrypted and gone, so another server means hands off.
+        echo "${SD_WARN}Trivy was pointed at ${DT_TRIVY_URL}, not at the server this module runs."
+        echo "${SD_WARN}Leaving the analyzer alone: its token cannot be recovered from v4."
+    elif [[ -z "${trivy_token}" ]]; then
+        echo "${SD_WARN}No Trivy token in secrets.env, leaving the analyzer alone."
+    else
+        # 409 means the secret survived from an earlier run, which is just as good.
+        local secret_body code
+        secret_body=$(N="${SECRET_NAME}" V="${trivy_token}" python3 -c \
+            'import json,os;print(json.dumps({"name":os.environ["N"],"value":os.environ["V"]}))')
+        code=$(call POST /secrets "${secret_body}")
+        if [[ "${code}" != "201" && "${code}" != "409" ]]; then
+            echo "${SD_WARN}Could not store the Trivy token as a Dependency-Track secret (HTTP ${code})."
+            echo "${SD_WARN}Configure the Trivy analyzer by hand, the values are in the module settings."
+        else
+            local body
+            body=$(U="${TRIVY_URL}" N="${SECRET_NAME}" \
+                E="${DT_TRIVY_ENABLED}" I="${DT_TRIVY_IGNORE_UNFIXED}" \
+                L="${DT_TRIVY_SCAN_LIBRARY}" O="${DT_TRIVY_SCAN_OS}" python3 -c '
+import json, os
+flag = lambda name: os.environ[name].strip().lower() == "true"
+print(json.dumps({"config": {
+    "enabled": flag("E"),
+    "apiUrl": os.environ["U"],
+    "apiToken": os.environ["N"],
+    "scanLibrary": flag("L"),
+    "scanOs": flag("O"),
+    "ignoreUnfixed": flag("I"),
+}}))')
+            if put_extension_config vuln-analyzer trivy "${body}"; then
+                # "prepared": secret and URL in place, but v4 had it off so it stays off.
+                if [[ "${DT_TRIVY_ENABLED}" == "true" ]]; then
+                    trivy_state=enabled
+                else
+                    trivy_state=prepared
+                fi
+            fi
+        fi
+    fi
+
+    local body
+    body=$(E="${DT_INTERNAL_ENABLED}" python3 -c \
+        'import json,os;print(json.dumps({"config":{"enabled":os.environ["E"].strip().lower()=="true"}}))')
+    put_extension_config vuln-analyzer internal "${body}" || true
+
+    body=$(E="${DT_NVD_ENABLED}" U="${DT_NVD_FEEDS_URL}" python3 -c \
+        'import json,os;print(json.dumps({"config":{"enabled":os.environ["E"].strip().lower()=="true","cveFeedsUrl":os.environ["U"]}}))')
+    put_extension_config vuln-data-source nvd "${body}" || true
+
+    # v4 stored the OSV ecosystems as a semicolon separated list, empty meaning off.
+    # v5 keeps them in an array and refuses an empty one while enabled.
+    body=$(L="${DT_OSV_ECOSYSTEMS}" U="${DT_OSV_URL}" A="${DT_OSV_ALIAS_SYNC}" python3 -c '
+import json, os
+ecosystems = [e.strip() for e in os.environ["L"].split(";") if e.strip()]
+config = {
+    "enabled": bool(ecosystems),
+    "dataUrl": os.environ["U"],
+    "aliasSyncEnabled": os.environ["A"].strip().lower() == "true",
+}
+if ecosystems:
+    config["ecosystems"] = ecosystems
+print(json.dumps({"config": config}))')
+    put_extension_config vuln-data-source osv "${body}" || true
+
+    # These need a token v4 encrypted and the migrator wiped, so v5 would reject
+    # them enabled. Store everything else, leaving the token as the only thing to
+    # type. VulnDB gets nothing: v4 authenticated with OAuth1, v5 wants OAuth2.
+    body=$(U="${DT_OSSINDEX_URL}" N="${DT_OSSINDEX_USERNAME}" A="${DT_OSSINDEX_ALIAS_SYNC}" python3 -c '
+import json, os
+config = {
+    "enabled": False,
+    "apiUrl": os.environ["U"],
+    "aliasSyncEnabled": os.environ["A"].strip().lower() == "true",
+}
+if os.environ["N"]:
+    config["username"] = os.environ["N"]
+print(json.dumps({"config": config}))')
+    put_extension_config vuln-analyzer oss-index "${body}" || true
+
+    body=$(U="${DT_GITHUB_URL}" A="${DT_GITHUB_ALIAS_SYNC}" python3 -c '
+import json, os
+print(json.dumps({"config": {
+    "enabled": False,
+    "apiUrl": os.environ["U"],
+    "aliasSyncEnabled": os.environ["A"].strip().lower() == "true",
+}}))')
+    put_extension_config vuln-data-source github "${body}" || true
+
+    body=$(U="${DT_SNYK_URL}" O="${DT_SNYK_ORG_ID}" A="${DT_SNYK_ALIAS_SYNC}" python3 -c '
+import json, os
+config = {
+    "enabled": False,
+    "apiBaseUrl": os.environ["U"],
+    "aliasSyncEnabled": os.environ["A"].strip().lower() == "true",
+}
+if os.environ["O"]:
+    config["orgId"] = os.environ["O"]
+print(json.dumps({"config": config}))')
+    put_extension_config vuln-analyzer snyk "${body}" || true
+
+    # v4 had these running, v5 wants a token we lost. Everything but their token
+    # is already in place, above.
+    local pending=""
+    add_pending() {
+        [[ "${2}" == "true" ]] && pending="${pending:+${pending}, }$1"
+        return 0
+    }
+    add_pending "OSS Index" "${DT_OSSINDEX_ENABLED}"
+    add_pending "GitHub Advisories" "${DT_GITHUB_ENABLED}"
+    add_pending "Snyk" "${DT_SNYK_ENABLED}"
+    add_pending "VulnDB" "${DT_VULNDB_ENABLED}"
+
+    python3 -c 'import agent; agent.set_env("DT_TRIVY_SETUP", "done")'
+
+    echo
+    echo "Upgrade complete. Analyzers carried over: trivy=${trivy_state}," \
+         "internal=${DT_INTERNAL_ENABLED}, nvd=${DT_NVD_ENABLED}, osv=[${DT_OSV_ECOSYSTEMS}]."
+    echo
+    echo "${SD_WARN}v5 cannot decrypt what v4 encrypted, so the migrator cleared every secret."
+    echo "${SD_WARN}Still to do by hand:"
+    if [[ -n "${pending}" ]]; then
+        echo "${SD_WARN}  - enter the API token of: ${pending}"
+        echo "${SD_WARN}    (everything else about them is already configured)"
+    fi
+    echo "${SD_WARN}  - re-enter the repository passwords, their repository is disabled"
+    echo "${SD_WARN}  - re-enter the integration keys"
+    echo "${SD_WARN}  - re-enable the notification rules, they came back disabled"
+    echo
+    echo "state/${V4_DUMP} is kept. Remove it once the instance is proven."
+}
+
+##
+## Entry point
+##
+
+POSTGRES_TOKEN=$(read_secret POSTGRES_TOKEN)
+if [[ -z "${POSTGRES_TOKEN}" ]]; then
+    fail "POSTGRES_TOKEN is not set in secrets.env"
+fi
+
+JDBC_SRC="jdbc:postgresql://${SRC_CTR}:5432/${DB}"
+JDBC_DST="jdbc:postgresql://${DST_CTR}:5432/${DB}"
+
+case "${1:-migrate}" in
+    migrate) phase_migrate ;;
+    analyzers) phase_analyzers ;;
+    *) fail "Usage: $0 [migrate|analyzers]" ;;
+esac

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -40,7 +40,7 @@ cd "${AGENT_STATE_DIR}"
 # Not in org.nethserver.images, so no *_IMAGE variable holds it. Bumped by hand,
 # and never past the apiserver 2.0.0 ships: it writes a Flyway head, which an
 # older apiserver would refuse. Behind is safe, Flyway catches up on first boot.
-V4_MIGRATOR_IMAGE="${V4_MIGRATOR_IMAGE:-ghcr.io/dependencytrack/v4-migrator:5.0.4}"
+V4_MIGRATOR_IMAGE="${V4_MIGRATOR_IMAGE:-ghcr.io/dependencytrack/v4-migrator:5.0.5}"
 
 SRC_CTR="dt_migrate_src"
 DST_CTR="dt_migrate_dst"
@@ -409,10 +409,11 @@ phase_migrate() {
     run_postgres "${DST_CTR}" "${DST_VOL}" \
         -c max_wal_size=4GB -c max_locks_per_transaction=256
 
-    # `run` gates the migration. `verify` is advisory upstream, kept for the row
-    # count table it logs, and only after the load: before it, every count hits a
-    # staging table nothing has created and raises a PostgreSQL error.
+    # Upstream's sequence. The preflight verify logs a PostgreSQL error per
+    # staging table nothing has created yet: that is how it reports zero, not a
+    # failure. `run` is what gates the migration, verify is advisory either side.
     run_migrator bootstrap
+    run_migrator verify
     run_migrator run \
         --source-url "${JDBC_SRC}" --source-user postgres --source-pass "${POSTGRES_TOKEN}" \
         --metrics-retention-days "${METRICS_RETENTION_DAYS}"

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -37,8 +37,9 @@ SELF=$(readlink -f "$0")
 
 cd "${AGENT_STATE_DIR}"
 
-# Not in org.nethserver.images, so no *_IMAGE variable holds it. Its version
-# need not match the apiserver: Flyway upgrades what it produced on first boot.
+# Not in org.nethserver.images, so no *_IMAGE variable holds it. Bumped by hand,
+# and never past the apiserver 2.0.0 ships: it writes a Flyway head, which an
+# older apiserver would refuse. Behind is safe, Flyway catches up on first boot.
 V4_MIGRATOR_IMAGE="${V4_MIGRATOR_IMAGE:-ghcr.io/dependencytrack/v4-migrator:5.0.4}"
 
 SRC_CTR="dt_migrate_src"

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -495,6 +495,16 @@ phase_analyzers() {
     . "./${ANALYZERS_ENV}"
     set +a
 
+    # v4 stores these with a trailing slash and copes with it; v5 concatenates
+    # and produces a double slash. On OSV that is fatal: the ecosystem archive
+    # at .../osv-vulnerabilities.storage.googleapis.com//Maven/all.zip answers
+    # 404, the mirror retries six times and gives up terminally.
+    DT_OSV_URL="${DT_OSV_URL%/}"
+    DT_NVD_FEEDS_URL="${DT_NVD_FEEDS_URL%/}"
+    DT_OSSINDEX_URL="${DT_OSSINDEX_URL%/}"
+    DT_GITHUB_URL="${DT_GITHUB_URL%/}"
+    DT_SNYK_URL="${DT_SNYK_URL%/}"
+
     systemctl --user enable "${UNITS[@]}" dependencytrack-setup.service
     systemctl --user start dependencytrack.service
 

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -161,10 +161,18 @@ BEGIN
         INSERT INTO "TEAM" ("NAME", "UUID")
             VALUES ('NethServer module', gen_random_uuid()::text) RETURNING "ID" INTO team_id;
     END IF;
+    -- v5 splits these into granular permissions, and the module only ever creates
+    -- a secret and updates an extension config. The umbrella SECRET_MANAGEMENT
+    -- and SYSTEM_CONFIGURATION would also let this key delete any secret and
+    -- rewrite notifications and repositories.
     INSERT INTO "TEAMS_PERMISSIONS" ("TEAM_ID", "PERMISSION_ID")
         SELECT team_id, "ID" FROM "PERMISSION"
-         WHERE "NAME" IN ('SECRET_MANAGEMENT', 'SYSTEM_CONFIGURATION')
+         WHERE "NAME" IN ('SECRET_MANAGEMENT_CREATE', 'SYSTEM_CONFIGURATION_UPDATE')
         ON CONFLICT DO NOTHING;
+    -- A renamed permission would leave the key silently unable to do its job.
+    IF (SELECT count(*) FROM "TEAMS_PERMISSIONS" WHERE "TEAM_ID" = team_id) < 2 THEN
+        RAISE EXCEPTION 'Expected 2 permissions on the module team, the v5 catalog has changed';
+    END IF;
     INSERT INTO "APIKEY" ("COMMENT", "CREATED", "SECRET_HASH", "PUBLIC_ID", "IS_LEGACY")
         VALUES ('Used by the NethServer module', now(), '${hash}', '${pub}', false)
         RETURNING "ID" INTO key_id;

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -51,10 +51,6 @@ cd "${AGENT_STATE_DIR}"
 # to read the v4 schema and write the v5 one: a later apiserver upgrades what it
 # produced through Flyway on its first boot.
 V4_MIGRATOR_IMAGE="${V4_MIGRATOR_IMAGE:-ghcr.io/dependencytrack/v4-migrator:5.0.4}"
-# Pre-pulled to shorten the outage. A mismatch with what 2.0.0 ships costs a
-# wasted download and nothing else, so this is never fatal.
-V5_APISERVER_IMAGE="${V5_APISERVER_IMAGE:-docker.io/dependencytrack/apiserver:5.0.4}"
-V5_FRONTEND_IMAGE="${V5_FRONTEND_IMAGE:-docker.io/dependencytrack/frontend:5.0.4}"
 
 SRC_CTR="dt_migrate_src"
 DST_CTR="dt_migrate_dst"
@@ -451,11 +447,11 @@ phase_migrate() {
     podman exec "${DST_CTR}" pg_dump -U postgres -Fc "${DB}" >"${V5_DUMP}"
     podman rm --ignore -f "${SRC_CTR}" "${DST_CTR}" >/dev/null
 
-    # Downloaded while the migrated dump is safe on disk but before the swap, so
-    # a slow registry does not stretch the window with a half-replaced volume.
-    podman pull "${V5_APISERVER_IMAGE}" "${V5_FRONTEND_IMAGE}" || \
-        echo "${SD_WARN}Could not pre-pull the v5 images, update-module will fetch them."
-
+    # The v5 images are deliberately not pre-pulled here. The instance is down
+    # from the start of this phase until the end of the analyzer phase, so
+    # fetching them early moves the download inside the same outage rather than
+    # shortening it, while pinning a tag in a released v4 script that can only
+    # drift from what 2.0.0 actually ships. update-module pulls the right ones.
     swap_in_migrated_database
 
     mark_pending

--- a/imageroot/scripts/upgrade2V5.sh
+++ b/imageroot/scripts/upgrade2V5.sh
@@ -77,7 +77,8 @@ SELF_COPY="upgrade2V5.sh"
 # Present means a previous run died while replacing postgres-data, so the next
 # run must resume instead of inspecting a volume that is empty at that point.
 SWAP_FLAG="${WORK_DIR}/.swap-in-progress"
-# Mandatory flag of `run`.
+# Mandatory flag of `run`. Portfolio metrics older than this are not copied over;
+# findings, audit history and everything else are unaffected.
 METRICS_RETENTION_DAYS=90
 
 fail() {
@@ -153,11 +154,17 @@ EOS
 DO \$\$
 DECLARE team_id bigint; key_id bigint;
 BEGIN
-    INSERT INTO "TEAM" ("NAME", "UUID")
-        VALUES ('NethServer module', gen_random_uuid()::text) RETURNING "ID" INTO team_id;
+    -- Reuse the team if an earlier run created it and then failed: "NAME" is
+    -- unique, so a plain insert would make every retry fail.
+    SELECT "ID" INTO team_id FROM "TEAM" WHERE "NAME" = 'NethServer module';
+    IF team_id IS NULL THEN
+        INSERT INTO "TEAM" ("NAME", "UUID")
+            VALUES ('NethServer module', gen_random_uuid()::text) RETURNING "ID" INTO team_id;
+    END IF;
     INSERT INTO "TEAMS_PERMISSIONS" ("TEAM_ID", "PERMISSION_ID")
         SELECT team_id, "ID" FROM "PERMISSION"
-         WHERE "NAME" IN ('SECRET_MANAGEMENT', 'SYSTEM_CONFIGURATION');
+         WHERE "NAME" IN ('SECRET_MANAGEMENT', 'SYSTEM_CONFIGURATION')
+        ON CONFLICT DO NOTHING;
     INSERT INTO "APIKEY" ("COMMENT", "CREATED", "SECRET_HASH", "PUBLIC_ID", "IS_LEGACY")
         VALUES ('Used by the NethServer module', now(), '${hash}', '${pub}', false)
         RETURNING "ID" INTO key_id;
@@ -201,6 +208,13 @@ EOS
         "${POSTGRES_IMAGE}" <"${V5_DUMP}"
 
     rm -f "${SWAP_FLAG}" "${V5_DUMP}" "${WORK_DIR}/${DB}_restore.sh"
+}
+
+# Keeps dependencytrack-setup.service of 2.0.0 from configuring Trivy on its own
+# defaults before the analyzer phase replays the v4 ones. Both exits of phase 1
+# need it, the resume path included.
+mark_pending() {
+    python3 -c 'import agent; agent.set_env("DT_TRIVY_SETUP", "pending-migration")'
 }
 
 next_step() {
@@ -267,9 +281,9 @@ phase_migrate() {
     # database. Every unit has to be disabled, not just the pod: the others are
     # WantedBy=default.target too, and their BindsTo would drag the pod back up.
     systemctl --user disable "${UNITS[@]}" >/dev/null 2>&1 || true
-    if systemctl --user --quiet is-active dependencytrack.service; then
-        systemctl --user stop dependencytrack.service
-    fi
+    # Every unit by name rather than the pod alone: not relying on BindsTo to
+    # tear the containers down before postgres-data is reopened below.
+    systemctl --user stop "${UNITS[@]}"
 
     # postgres-data is empty or half loaded here: inspecting it would conclude
     # "fresh install" and replace a database that is already migrated.
@@ -280,6 +294,7 @@ phase_migrate() {
         fi
         echo "Resuming an interrupted migration from state/${V5_DUMP}."
         swap_in_migrated_database
+        mark_pending
         completed=1
         next_step
         return 0
@@ -327,13 +342,17 @@ phase_migrate() {
 
     # An unreadable property must stop the run: recording the v4 default as if
     # it were the admin's setting would push a wrong value into v5.
+    # Appends on its own rather than under a `{ ... } >file` block: such a block
+    # would capture the message of fail(), and the whole EXIT trap, into the file
+    # and leave the journal empty.
     save_v4_property() {
         local value
         value=$(read_v4_property "$2" "$3" "$4") ||
             fail "Could not read the v4 setting $2/$3 from the database."
-        printf '%s=%q\n' "$1" "${value}"
+        printf '%s=%q\n' "$1" "${value}" >>"${ANALYZERS_ENV}.tmp"
     }
 
+    : >"${ANALYZERS_ENV}.tmp"
     {
         save_v4_property DT_TRIVY_URL scanner trivy.base.url ""
         save_v4_property DT_TRIVY_ENABLED scanner trivy.enabled false
@@ -358,7 +377,8 @@ phase_migrate() {
         save_v4_property DT_SNYK_ORG_ID scanner snyk.org.id ""
         save_v4_property DT_SNYK_ALIAS_SYNC scanner snyk.alias.sync.enabled false
         save_v4_property DT_VULNDB_ENABLED scanner vulndb.enabled false
-    } >"${ANALYZERS_ENV}"
+    }
+    mv "${ANALYZERS_ENV}.tmp" "${ANALYZERS_ENV}"
     echo "v4 analyzer settings saved to state/${ANALYZERS_ENV}"
 
     mkdir -p "${BACKUP_DIR}"
@@ -393,10 +413,7 @@ phase_migrate() {
 
     swap_in_migrated_database
 
-    # Keeps dependencytrack-setup.service of 2.0.0 from configuring Trivy on its
-    # own defaults before the analyzer phase replays the v4 ones.
-    python3 -c 'import agent; agent.set_env("DT_TRIVY_SETUP", "pending-migration")'
-
+    mark_pending
     completed=1
     next_step
 }
@@ -410,22 +427,33 @@ phase_analyzers() {
         fail "state/${ANALYZERS_ENV} is missing: run the migration phase first."
     fi
 
+    # Shipped by 2.0.0 only. Run out of order this phase would start a v4
+    # apiserver against the migrated v5 database, the one thing phase 1 exists
+    # to prevent.
+    if [[ ! -f "${AGENT_INSTALL_DIR}/systemd/user/dependencytrack-setup.service" ]]; then
+        fail "This instance is not on 2.0.0 yet. Update it first, then run this phase:" \
+             "see the command printed at the end of the migration phase."
+    fi
+
     local api_key trivy_token
     api_key=$(read_secret DT_API_KEY)
     trivy_token=$(read_secret TRIVY_TOKEN)
-    if [[ -z "${api_key}" ]]; then
-        fail "No DT_API_KEY in secrets.env: configure the analyzers by hand."
-    fi
 
     set -a
     # shellcheck disable=SC1090
     . "./${ANALYZERS_ENV}"
     set +a
 
-    systemctl --user enable "${UNITS[@]}"
-    # Shipped by 2.0.0 only, and it stands down while DT_TRIVY_SETUP is set.
-    systemctl --user enable dependencytrack-setup.service 2>/dev/null || true
+    systemctl --user enable "${UNITS[@]}" dependencytrack-setup.service
     systemctl --user start dependencytrack.service
+
+    # Bringing the instance back up matters more than the analyzers, so this is
+    # checked once the services are running, not before.
+    if [[ -z "${api_key}" ]]; then
+        python3 -c 'import agent; agent.set_env("DT_TRIVY_SETUP", "")'
+        fail "No DT_API_KEY in secrets.env. The instance is up and its data is migrated," \
+             "but the analyzers have to be configured by hand."
+    fi
 
     local api="http://127.0.0.1:${TCP_PORT}/api"
     # The apiserver runs its init tasks before serving, and the first v5 boot
@@ -453,6 +481,7 @@ phase_analyzers() {
 
     # 304 means what we sent is already stored, which happens whenever a v4
     # setting matches the v5 default.
+    failed=""
     put_extension_config() {
         local point="$1" extension="$2" body="$3" code
         code=$(call PUT "/extension-points/${point}/extensions/${extension}/config" "${body}")
@@ -460,13 +489,17 @@ phase_analyzers() {
             200 | 204 | 304) return 0 ;;
         esac
         echo "${SD_WARN}Could not configure ${extension} (HTTP ${code}), do it by hand."
+        failed="${failed:+${failed}, }${extension}"
         return 1
     }
 
     local trivy_state=none
-    if [[ -n "${DT_TRIVY_URL}" && "${DT_TRIVY_URL}" != "${TRIVY_URL}" ]]; then
+    # v4 stores whatever was typed, so compare without a trailing slash: the
+    # module's own Trivy is the one analyzer whose token can be recovered.
+    local v4_trivy_url="${DT_TRIVY_URL%/}"
+    if [[ -n "${v4_trivy_url}" && "${v4_trivy_url}" != "${TRIVY_URL}" ]]; then
         # Their token is encrypted and gone, so another server means hands off.
-        echo "${SD_WARN}Trivy was pointed at ${DT_TRIVY_URL}, not at the server this module runs."
+        echo "${SD_WARN}Trivy was pointed at ${v4_trivy_url}, not at the server this module runs."
         echo "${SD_WARN}Leaving the analyzer alone: its token cannot be recovered from v4."
     elif [[ -z "${trivy_token}" ]]; then
         echo "${SD_WARN}No Trivy token in secrets.env, leaving the analyzer alone."
@@ -580,8 +613,13 @@ print(json.dumps({"config": config}))')
     python3 -c 'import agent; agent.set_env("DT_TRIVY_SETUP", "done")'
 
     echo
-    echo "Upgrade complete. Analyzers carried over: trivy=${trivy_state}," \
-         "internal=${DT_INTERNAL_ENABLED}, nvd=${DT_NVD_ENABLED}, osv=[${DT_OSV_ECOSYSTEMS}]."
+    if [[ -n "${failed}" ]]; then
+        echo "${SD_WARN}Upgrade complete, but these analyzers were rejected and keep the v5"
+        echo "${SD_WARN}defaults: ${failed}. Configure them by hand."
+    else
+        echo "Upgrade complete. Analyzers carried over: trivy=${trivy_state}," \
+             "internal=${DT_INTERNAL_ENABLED}, nvd=${DT_NVD_ENABLED}, osv=[${DT_OSV_ECOSYSTEMS}]."
+    fi
     echo
     echo "${SD_WARN}v5 cannot decrypt what v4 encrypted, so the migrator cleared every secret."
     echo "${SD_WARN}Still to do by hand:"

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,19 @@
   "extends": [
     "local>NethServer/.github:ns8-automerge"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Follow the v4-migrator tag pinned in the upgrade script",
+      "managerFilePatterns": [
+        "imageroot/scripts/upgrade2V5.sh"
+      ],
+      "matchStrings": [
+        "V4_MIGRATOR_IMAGE:-(?<depName>[^:\\s]+):(?<currentValue>[^}\"\\s]+)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "matchDatasources": ["docker"],
@@ -11,6 +24,12 @@
         "dependencytrack/frontend"
       ],
       "allowedVersions": "<5"
+    },
+    {
+      "description": "The migrator writes the schema 2.0.0 expects, so it must not go past v5",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/dependencytrack/v4-migrator"],
+      "allowedVersions": "<6"
     },
     {
       "matchDatasources": ["docker"],

--- a/renovate.json
+++ b/renovate.json
@@ -3,19 +3,6 @@
   "extends": [
     "local>NethServer/.github:ns8-automerge"
   ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Follow the v4-migrator tag pinned in the upgrade script",
-      "managerFilePatterns": [
-        "imageroot/scripts/upgrade2V5.sh"
-      ],
-      "matchStrings": [
-        "V4_MIGRATOR_IMAGE:-(?<depName>[^:\\s]+):(?<currentValue>[^}\"\\s]+)"
-      ],
-      "datasourceTemplate": "docker"
-    }
-  ],
   "packageRules": [
     {
       "matchDatasources": ["docker"],
@@ -24,12 +11,6 @@
         "dependencytrack/frontend"
       ],
       "allowedVersions": "<5"
-    },
-    {
-      "description": "The migrator writes the schema 2.0.0 expects, so it must not go past v5",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/dependencytrack/v4-migrator"],
-      "allowedVersions": "<6"
     },
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
Dependency-Track v5 lands in #130 with no migration code. The script that gets an instance from v4 to v5 has to reach it **while it is still on v4**, so it ships here: today's module plus the script, Dependency-Track stays on 4.14.3.

### `imageroot/scripts/upgrade2V5.sh`

Runs as the module user on the node hosting the instance, in two phases around the update:

    runagent -m dependencytrack1 bash ../scripts/upgrade2V5.sh
    # from the leader: api-cli run update-module ... :2.0.0
    runagent -m dependencytrack1 bash upgrade2V5.sh analyzers

Phase 1 prints what v5 cannot carry over, asks for `I have a backup`, then stops and disables every unit, keeps the v4 dump in `state/backup-v4/`, saves the v4 analyzer settings before the migrator wipes them, runs the official `v4-migrator` against a throwaway postgres and swaps `postgres-data`.

Phase 2 refuses to run unless the instance is on 2.0.0, starts the services, replays the v4 analyzer settings and prints what is left to do by hand.

Two things worth knowing:

- The update deletes every file 2.0.0 does not ship, this script included, so phase 1 keeps a copy in `state/`.
- Every unit is disabled between the phases, not just the pod: the others are `WantedBy=default.target` and their `BindsTo` would drag the pod back up after a reboot, onto a migrated database.

An interrupted swap resumes from the migrated dump. Any other failure exits non-zero with the services down.

## Related issue

Companion to #130. Issues are disabled on this repository and no `NethServer/dev` issue tracks this.

## How to test

On a 1.0.11 instance with real data — projects, a BOM, findings, audited findings, users, teams with API keys, policies, notification rules, repositories with passwords:

1. Update to this branch's image, check nothing changed.
2. `runagent -m dependencytrack1 bash ../scripts/upgrade2V5.sh` — v4 dump in `state/backup-v4/`, settings in `state/migrate-v5/analyzers.env`, pod stopped **and disabled**.
3. `api-cli run update-module` to 2.0.0, services stay down.
4. `runagent -m dependencytrack1 bash upgrade2V5.sh analyzers`.
5. Check the data and the analyzer switches in the interface.

Killing phase 1 during the swap and running it again must resume, not report a fresh install.

## Dependencies

Publish this before 2.0.0 (#130).
